### PR TITLE
Stabilize top-bar icon startup and migrate development workflow to Pixi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 .idea
 node_modules
+.pixi
+.pnpm-store
+.pnpm-home
+.npm-cache
+.corepack
 .DS_Store
 .eslintcache
 dist

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+store-dir=.pnpm-store
+cache=.npm-cache

--- a/README.md
+++ b/README.md
@@ -90,15 +90,23 @@ After installation, please go to the plugin settings page first:
 
 ## 开发
 
+本项目使用 `pixi` 管理开发环境，依赖与缓存默认都放在项目目录下（如 `.pixi`、`.pnpm-store`、`node_modules`）。
+
 ```bash
-# 安装依赖
-npm install
+# 初始化 pixi 环境（仅首次）
+pixi install
+
+# 安装 Node 依赖
+pixi run install
 
 # 开发模式
-npm run dev
+pixi run dev
+
+# 代码检查
+pixi run lint
 
 # 构建
-npm run build
+pixi run build
 ```
 
 ## 许可证

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -48,3 +48,24 @@
 ### 0.2.0
 - 触发事件改为`loaded-protyle-static`( [#1](https://github.com/dale0525/siyuan-auto-seq-number/issues/1) )
 - 改用::before伪元素实现序号，并使用SessionStorage缓存序号，避免聚焦时序号重置( [#2](https://github.com/dale0525/siyuan-auto-seq-number/issues/2), [#3](https://github.com/dale0525/siyuan-auto-seq-number/issues/3) )
+
+## 开发
+
+本项目使用 `pixi` 管理开发环境，依赖与缓存默认都放在项目目录下（如 `.pixi`、`.pnpm-store`、`node_modules`）。
+
+```bash
+# 初始化 pixi 环境（仅首次）
+pixi install
+
+# 安装 Node 依赖
+pixi run install
+
+# 开发模式
+pixi run dev
+
+# 代码检查
+pixi run lint
+
+# 构建
+pixi run build
+```

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,0 +1,424 @@
+version: 6
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-20.19.6-hfe5e47f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pnpm-9.15.3-ha573bdf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.2-h14c5de8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-21.1.8-h4fb565c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.51.0-h58003a5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/nodejs-20.19.6-hf63971a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.1-hb6871ef_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pnpm-9.15.3-h824c07a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.1-hd23fc13_2.conda
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.2-h38cb7af_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-21.1.8-h55c6f16_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.51.0-h6caf38d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-20.19.6-hf0fe506_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.1-hd24854e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pnpm-9.15.3-hd5b824e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/win-64/nodejs-20.19.6-h80290e7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pnpm-9.15.3-h76997c0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h41ae7f8_34.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_34.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_34.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
+  md5: d7c89558ba9fa0495403155b64376d81
+  license: None
+  size: 2562
+  timestamp: 1578324546067
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+  build_number: 16
+  sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+  md5: 73aaf86a425cc6e73fcf236a5a46396d
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23621
+  timestamp: 1650670423406
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
+  sha256: b5974ec9b50e3c514a382335efa81ed02b05906849827a34061c496f4defa0b2
+  md5: bddacf101bb4dd0e51811cb69c7790e2
+  depends:
+  - __unix
+  license: ISC
+  size: 146519
+  timestamp: 1767500828366
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
+  sha256: 142a722072fa96cf16ff98eaaf641f54ab84744af81754c292cb81e0881c0329
+  md5: 186a18e3ba246eccfc7cff00cd19a870
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  size: 12728445
+  timestamp: 1767969922681
+- conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.2-h14c5de8_0.conda
+  sha256: f3066beae7fe3002f09c8a412cdf1819f49a2c9a485f720ec11664330cf9f1fe
+  md5: 30334add4de016489b731c6662511684
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 12263724
+  timestamp: 1767970604977
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.2-h38cb7af_0.conda
+  sha256: d4cefbca587429d1192509edc52c88de52bc96c2447771ddc1f8bee928aed5ef
+  md5: 1e93aca311da0210e660d2247812fa02
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 12358010
+  timestamp: 1767970350308
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-21.1.8-h4fb565c_2.conda
+  sha256: 2619d471c50c466320e2aea906a4363e34efe181e61346e4453bc68264c5185f
+  md5: 1ac756454e65fb3fd7bc7de599526e43
+  depends:
+  - __osx >=10.13
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 571912
+  timestamp: 1770237202404
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-21.1.8-h55c6f16_2.conda
+  sha256: 5fbeb2fc2673f0455af6079abf93faaf27f11a92574ad51565fa1ecac9a4e2aa
+  md5: 4cb5878bdb9ebfa65b7cdff5445087c5
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 570068
+  timestamp: 1770238262922
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_17.conda
+  sha256: 43860222cf3abf04ded0cf24541a105aa388e0e1d4d6ca46258e186d4e87ae3e
+  md5: 3c281169ea25b987311400d7a7e28445
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgcc-ng ==15.2.0=*_17
+  - libgomp 15.2.0 he0feb66_17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1040478
+  timestamp: 1770252533873
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_17.conda
+  sha256: b961b5dd9761907a7179678b58a69bb4fc16b940eb477f635aea3aec0a3f17a6
+  md5: 51b78c6a757575c0d12f4401ffc67029
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 603334
+  timestamp: 1770252441199
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_17.conda
+  sha256: 50c48cd3716a2e58e8e2e02edc78fef2d08fffe1e3b1ed40eb5f87e7e2d07889
+  md5: 24c2fe35fa45cd71214beba6f337c071
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc 15.2.0 he0feb66_17
+  constrains:
+  - libstdcxx-ng ==15.2.0=*_17
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 5852406
+  timestamp: 1770252584235
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
+  sha256: c180f4124a889ac343fc59d15558e93667d894a966ec6fdb61da1604481be26b
+  md5: 0f03292cc56bf91a077a134ea8747118
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  size: 895108
+  timestamp: 1753948278280
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.51.0-h58003a5_1.conda
+  sha256: d90dd0eee6f195a5bd14edab4c5b33be3635b674b0b6c010fb942b956aa2254c
+  md5: fbfc6cf607ae1e1e498734e256561dc3
+  depends:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 422612
+  timestamp: 1753948458902
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.51.0-h6caf38d_1.conda
+  sha256: 042c7488ad97a5629ec0a991a8b2a3345599401ecc75ad6a5af73b60e6db9689
+  md5: c0d87c3c8e075daf1daf6c31b53e8083
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 421195
+  timestamp: 1753948426421
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+  sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
+  md5: edb0dca6bc32e4f4789199455a1dbeb8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 60963
+  timestamp: 1727963148474
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
+  sha256: 8412f96504fc5993a63edf1e211d042a1fd5b1d51dedec755d2058948fcced09
+  md5: 003a54a4e32b02f7355b50a837e699da
+  depends:
+  - __osx >=10.13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 57133
+  timestamp: 1727963183990
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+  sha256: ce34669eadaba351cd54910743e6a2261b67009624dbc7daeeafdef93616711b
+  md5: 369964e85dc26bfe78f41399b366c435
+  depends:
+  - __osx >=11.0
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  size: 46438
+  timestamp: 1727963202283
+- conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-20.19.6-hfe5e47f_2.conda
+  sha256: d3c75f8c6d3b57fb2f1c8f7c4d4a4e7da7879630a12eb8ea920e3d81e060bd18
+  md5: 74e25a4721f3f8d7917e101f410d4fd5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.2,<79.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libuv >=1.51.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.5,<4.0a0
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 17298015
+  timestamp: 1770645431810
+- conda: https://conda.anaconda.org/conda-forge/osx-64/nodejs-20.19.6-hf63971a_2.conda
+  sha256: 9cba9ebbf344614700fabe2a978f19e0e0d9f0a7d74cdf2d5085a62487684845
+  md5: 9b2085394712b431983ba2330506f181
+  depends:
+  - __osx >=11.0
+  - icu >=78.2,<79.0a0
+  - libcxx >=19
+  - libuv >=1.51.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.5,<4.0a0
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 11673961
+  timestamp: 1770643992042
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-20.19.6-hf0fe506_2.conda
+  sha256: d107dee13e476b9c7cc0e86192bfa0bf9bacae0fee88bcd04bd3b4a95b7760cc
+  md5: 3d17b7c65982116389837b9b7d068412
+  depends:
+  - __osx >=11.0
+  - icu >=78.2,<79.0a0
+  - libcxx >=19
+  - libuv >=1.51.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.5,<4.0a0
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 11246896
+  timestamp: 1770644880630
+- conda: https://conda.anaconda.org/conda-forge/win-64/nodejs-20.19.6-h80290e7_2.conda
+  sha256: 971ff62eb1702574e1fa415b3811d831ef4950e87a8e73e093ea54698339903a
+  md5: e9f57242fbac4537a02d7e3841c22d93
+  license: MIT
+  license_family: MIT
+  size: 22913658
+  timestamp: 1770638922488
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
+  sha256: 44c877f8af015332a5d12f5ff0fb20ca32f896526a7d0cdb30c769df1144fb5c
+  md5: f61eb8cd60ff9057122a3d338b99c00f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  size: 3164551
+  timestamp: 1769555830639
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.1-hb6871ef_1.conda
+  sha256: e02e5639b0e4d6d4fcf0f3b082642844fb5a37316f5b0a1126c6271347462e90
+  md5: 30bb8d08b99b9a7600d39efb3559fff0
+  depends:
+  - __osx >=10.13
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 2777136
+  timestamp: 1769557662405
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.1-hd24854e_1.conda
+  sha256: 361f5c5e60052abc12bdd1b50d7a1a43e6a6653aab99a2263bf2288d709dcf67
+  md5: f4f6ad63f98f64191c3e77c5f5f29d76
+  depends:
+  - __osx >=11.0
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 3104268
+  timestamp: 1769556384749
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pnpm-9.15.3-ha573bdf_0.conda
+  sha256: d31569cbde40e7c314578b76de71ece999f500663fe7fd0aaebd00f7a184f80e
+  md5: c61b8caea02ee928b45456a1b4c49c24
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - nodejs >=20.18.1,<21.0a0
+  license: MIT
+  license_family: MIT
+  size: 3279895
+  timestamp: 1736151845373
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pnpm-9.15.3-h824c07a_0.conda
+  sha256: 5fe1371622e2193a670e511c3280217f6a0aeb2871d440301946a087005ee947
+  md5: 8d135e0cec656ea50d7a308392dbfd51
+  depends:
+  - __osx >=10.13
+  - libcxx >=18
+  - nodejs >=20.18.1,<21.0a0
+  license: MIT
+  license_family: MIT
+  size: 3335008
+  timestamp: 1736152008480
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pnpm-9.15.3-hd5b824e_0.conda
+  sha256: f59179f3a4df6f4d7eb371c394b61c4916f9bd5ccfcb339906ae5d0d524b0c1c
+  md5: 85bd93035ac03bd81a8005eff2640fdb
+  depends:
+  - __osx >=11.0
+  - libcxx >=18
+  - nodejs >=20.18.1,<21.0a0
+  license: MIT
+  license_family: MIT
+  size: 3343093
+  timestamp: 1736152121893
+- conda: https://conda.anaconda.org/conda-forge/win-64/pnpm-9.15.3-h76997c0_0.conda
+  sha256: fb8f250756e1d9f6924cc0ad6001d4b1169f4cf68e6d77ac0c7477342c9e2a95
+  md5: 259febd6527af9e7180ce5387de720f5
+  depends:
+  - nodejs >=20.18.1,<21.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 3262969
+  timestamp: 1736152473033
+- conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+  sha256: 3005729dce6f3d3f5ec91dfc49fc75a0095f9cd23bab49efb899657297ac91a5
+  md5: 71b24316859acd00bdb8b38f5e2ce328
+  constrains:
+  - vc14_runtime >=14.29.30037
+  - vs2015_runtime >=14.29.30037
+  license: LicenseRef-MicrosoftWindowsSDK10
+  size: 694692
+  timestamp: 1756385147981
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h41ae7f8_34.conda
+  sha256: 9dc40c2610a6e6727d635c62cced5ef30b7b30123f5ef67d6139e23d21744b3a
+  md5: 1e610f2416b6acdd231c5f573d754a0f
+  depends:
+  - vc14_runtime >=14.44.35208
+  track_features:
+  - vc14
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19356
+  timestamp: 1767320221521
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_34.conda
+  sha256: 02732f953292cce179de9b633e74928037fa3741eb5ef91c3f8bae4f761d32a5
+  md5: 37eb311485d2d8b2c419449582046a42
+  depends:
+  - ucrt >=10.0.20348.0
+  - vcomp14 14.44.35208 h818238b_34
+  constrains:
+  - vs2015_runtime 14.44.35208.* *_34
+  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+  license_family: Proprietary
+  size: 683233
+  timestamp: 1767320219644
+- conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_34.conda
+  sha256: 878d5d10318b119bd98ed3ed874bd467acbe21996e1d81597a1dbf8030ea0ce6
+  md5: 242d9f25d2ae60c76b38a5e42858e51d
+  depends:
+  - ucrt >=10.0.20348.0
+  constrains:
+  - vs2015_runtime 14.44.35208.* *_34
+  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+  license_family: Proprietary
+  size: 115235
+  timestamp: 1767320173250
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
+  sha256: 5d7c0e5f0005f74112a34a7425179f4eb6e73c92f5d109e6af4ddeca407c92ab
+  md5: c9f075ab2f33b3bbee9e62d4ad0a6cd8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib 1.3.1 hb9d3cd8_2
+  license: Zlib
+  license_family: Other
+  size: 92286
+  timestamp: 1727963153079
+- conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.1-hd23fc13_2.conda
+  sha256: 219edbdfe7f073564375819732cbf7cc0d7c7c18d3f546a09c2dfaf26e4d69f3
+  md5: c989e0295dcbdc08106fe5d9e935f0b9
+  depends:
+  - __osx >=10.13
+  - libzlib 1.3.1 hd23fc13_2
+  license: Zlib
+  license_family: Other
+  size: 88544
+  timestamp: 1727963189976
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
+  sha256: 58f8860756680a4831c1bf4f294e2354d187f2e999791d53b1941834c4b37430
+  md5: e3170d898ca6cb48f1bb567afb92f775
+  depends:
+  - __osx >=11.0
+  - libzlib 1.3.1 h8359307_2
+  license: Zlib
+  license_family: Other
+  size: 77606
+  timestamp: 1727963209370

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,22 @@
+[workspace]
+authors = ["Logic Tan <logictan89@gmail.com>"]
+channels = ["conda-forge"]
+name = "siyuan-auto-seq-number"
+platforms = ["linux-64", "osx-64", "osx-arm64", "win-64"]
+version = "0.1.0"
+
+[activation.env]
+PNPM_HOME = "$PIXI_PROJECT_ROOT/.pnpm-home"
+PNPM_STORE_DIR = "$PIXI_PROJECT_ROOT/.pnpm-store"
+NPM_CONFIG_CACHE = "$PIXI_PROJECT_ROOT/.npm-cache"
+COREPACK_HOME = "$PIXI_PROJECT_ROOT/.corepack"
+
+[tasks]
+install = "pnpm install --frozen-lockfile"
+dev = "pnpm dev"
+build = "pnpm build"
+lint = "pnpm lint"
+
+[dependencies]
+nodejs = "20.*"
+pnpm = "9.*"

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,16 +29,20 @@ const DEFAULT_CONFIG: IPluginConfig = {
     docEnableStatus: {},
 };
 
+const TOP_BAR_ICON_SVG =
+    '<svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M4 6h16v2H4zm0 5h16v2H4zm0 5h16v2H4z"/></svg>';
+
 export default class HeaderNumberPlugin extends Plugin {
     public config!: IPluginConfig;
     private updateTimer: number | null = null;
-    private lastInputTime: number = 0;
+    private lastInputTime = 0;
     private activeDocId: string | null = null;
     private activeProtyle: any;
-    private shouldUpdate: boolean = false;
+    private shouldUpdate = false;
     private activeBlockId: string | null = null;
     private topBarElement: HTMLElement | null = null;
-    private version: string = "";
+    private topBarSyncTimers: number[] = [];
+    private version = "";
 
     async onload() {
         this.version = await getVersion();
@@ -205,9 +209,6 @@ export default class HeaderNumberPlugin extends Plugin {
             },
         });
 
-        // 初始化顶部工具栏
-        this.initTopBar();
-
         // 监听编辑器加载事件
         this.eventBus.on("loaded-protyle-dynamic", this.onProtyleLoaded);
         this.eventBus.on("loaded-protyle-static", this.onProtyleLoaded);
@@ -218,11 +219,16 @@ export default class HeaderNumberPlugin extends Plugin {
         }
     }
 
+    onLayoutReady() {
+        this.initTopBar();
+    }
+
     async onunload() {
         // 清理定时器
         if (this.updateTimer) {
             clearTimeout(this.updateTimer);
         }
+        this.clearTopBarSyncTimers();
         // 移除事件监听
         this.eventBus.off("loaded-protyle-dynamic", this.onProtyleLoaded);
         this.eventBus.off("loaded-protyle-static", this.onProtyleLoaded);
@@ -249,39 +255,41 @@ export default class HeaderNumberPlugin extends Plugin {
     }
 
     private changeDocEnableStatus(enabled: boolean | null) {
-        if (!this.activeDocId) {
-            this.topBarElement?.classList.remove("active");
+        if (!this.activeDocId || enabled === null) {
+            this.updateTopBarActiveState();
             return;
         }
-        if (enabled === null) {
-            this.topBarElement?.classList.remove("active");
-            return;
-        }
+
         if (enabled) {
             this.enableDoc(this.activeDocId);
-            this.topBarElement?.classList.add("active");
         } else {
             this.disableDoc(this.activeDocId);
-            this.topBarElement?.classList.remove("active");
         }
+
+        this.updateTopBarActiveState();
     }
 
     private initTopBar() {
+        if (this.topBarElement) {
+            this.syncTopBarElement();
+            this.updateTopBarActiveState();
+            this.scheduleTopBarSync();
+            return;
+        }
+
         // 添加标题序号切换按钮
         this.topBarElement = this.addTopBar({
-            icon: "iconList",
+            icon: TOP_BAR_ICON_SVG,
             title: this.i18n.toggleHeaderNumber,
             callback: async () => {
                 if (this.isDocEnabled(this.activeDocId)) {
                     await this.clearDocNumbering(this.activeProtyle);
                     showMessage(this.i18n.numberingDisabled);
                     this.disableDoc(this.activeDocId);
-                    this.topBarElement?.classList.remove("active");
                 } else {
                     await this.updateDocNumbering(this.activeProtyle);
                     showMessage(this.i18n.numberingEnabled);
                     this.enableDoc(this.activeDocId);
-                    this.topBarElement?.classList.add("active");
                 }
                 this.changeDocEnableStatus(this.isDocEnabled(this.activeDocId));
             },
@@ -290,29 +298,71 @@ export default class HeaderNumberPlugin extends Plugin {
         // 添加自定义类名
         if (this.topBarElement) {
             this.topBarElement.classList.add("toolbar__item--auto-seq-number");
-            // 根据当前文档状态设置激活状态
-            if (this.activeDocId && this.isDocEnabled(this.activeDocId)) {
-                this.topBarElement?.classList.add("active");
-            }
         }
+
+        this.syncTopBarElement();
+        this.updateTopBarActiveState();
+        this.scheduleTopBarSync();
+    }
+
+    private updateTopBarActiveState() {
+        if (!this.topBarElement) {
+            return;
+        }
+
+        if (this.activeDocId && this.isDocEnabled(this.activeDocId)) {
+            this.topBarElement.classList.add("active");
+            return;
+        }
+
+        this.topBarElement.classList.remove("active");
+    }
+
+    private syncTopBarElement() {
+        if (!this.topBarElement) {
+            return;
+        }
+
+        const toolbarElement = document.querySelector("#toolbar");
+        if (!toolbarElement) {
+            return;
+        }
+
+        if (!document.contains(this.topBarElement)) {
+            const barPluginsElement = toolbarElement.querySelector("#barPlugins");
+            barPluginsElement?.before(this.topBarElement);
+        }
+
+        window.dispatchEvent(new Event("resize"));
+    }
+
+    private scheduleTopBarSync() {
+        this.clearTopBarSyncTimers();
+
+        [0, 300, 1000].forEach((delay) => {
+            const timerId = window.setTimeout(() => {
+                this.syncTopBarElement();
+                this.updateTopBarActiveState();
+            }, delay);
+            this.topBarSyncTimers.push(timerId);
+        });
+    }
+
+    private clearTopBarSyncTimers() {
+        this.topBarSyncTimers.forEach((timerId) => {
+            clearTimeout(timerId);
+        });
+        this.topBarSyncTimers = [];
     }
 
     private onProtyleLoaded = async (e: CustomEvent) => {
+        this.initTopBar();
         this.activeProtyle = e.detail.protyle;
         this.activeDocId = this.getDocId(this.activeProtyle);
         if (!this.activeDocId) return;
 
         // 更新状态栏显示
         this.changeDocEnableStatus(this.isDocEnabled(this.activeDocId));
-
-        // 更新顶部工具栏状态
-        if (this.topBarElement) {
-            if (this.isDocEnabled(this.activeDocId)) {
-                this.topBarElement.classList.add("active");
-            } else {
-                this.topBarElement.classList.remove("active");
-            }
-        }
 
         // 检查文档是否启用了序号
         if (this.isDocEnabled(this.activeDocId)) {
@@ -344,11 +394,14 @@ export default class HeaderNumberPlugin extends Plugin {
         }
     };
 
-    private onDocClosed = (e: CustomEvent) => {
+    private onDocClosed = () => {
+        this.activeDocId = null;
+        this.activeProtyle = null;
         this.changeDocEnableStatus(null);
     };
 
     private onDocSwitch = (e: CustomEvent) => {
+        this.initTopBar();
         this.activeProtyle = e.detail.protyle;
         this.activeDocId = this.getDocId(this.activeProtyle);
         this.activeBlockId = null;
@@ -419,15 +472,6 @@ export default class HeaderNumberPlugin extends Plugin {
             // 获取所有标题元素
             const headerElements = this.getHeaderElements(protyle);
             if (!headerElements.length) return;
-
-            // 收集所有存在的标题级别并排序
-            const existingLevels = Array.from(
-                new Set(
-                    Array.from(headerElements)
-                        .map((element: Element) => getHeaderLevel(element))
-                        .filter((level: number) => level > 0)
-                )
-            ).sort((a: number, b: number) => a - b);
 
             // 准备更新
             const updates: Record<string, string> = {};
@@ -506,15 +550,6 @@ export default class HeaderNumberPlugin extends Plugin {
             // 获取所有标题元素
             const headerElements = this.getHeaderElements(protyle);
             if (!headerElements.length) return;
-
-            // 收集所有存在的标题级别并排序
-            const existingLevels = Array.from(
-                new Set(
-                    Array.from(headerElements)
-                        .map((element: Element) => getHeaderLevel(element))
-                        .filter((level: number) => level > 0)
-                )
-            ).sort((a: number, b: number) => a - b);
 
             // 准备更新
             const updates: Record<string, string> = {};


### PR DESCRIPTION
## Summary
This PR addresses issue #21 by making the plugin top-bar icon render reliably after startup, and also migrates the development workflow to Pixi so all environment tooling and caches are managed locally in the project.

## What Changed
- Switched development environment management to Pixi:
  - Added `pixi.toml` and `pixi.lock` with pinned `nodejs` + `pnpm` in a reproducible workspace.
  - Added project-local npm/pnpm cache settings via `.npmrc` and Pixi activation env vars.
  - Updated `.gitignore` to ignore `.pixi`, local pnpm/npm/corepack cache directories.
  - Updated `README.md` and `README_zh_CN.md` with Pixi-based setup and task commands.
- Fixed intermittent top-bar icon visibility in `src/index.ts`:
  - Added `onLayoutReady()` initialization for top-bar setup.
  - Switched toolbar icon source from `iconList` id to an inline SVG constant to avoid theme/icon registration timing issues.
  - Added robust top-bar synchronization logic:
    - `syncTopBarElement()` re-attaches the button if needed.
    - `scheduleTopBarSync()` retries sync at staggered delays (0ms / 300ms / 1000ms) and dispatches resize for layout recalculation.
    - `clearTopBarSyncTimers()` to clean timers on unload.
  - Centralized active-state rendering with `updateTopBarActiveState()` and ensured document switch/close paths refresh state.

## Why
Issue #21 reports that the plugin icon in the upper-right corner sometimes appears and sometimes disappears after restarting SiYuan (notably under certain themes). The behavior is consistent with startup timing/layout race conditions in top-bar mounting and visibility recalculation. The new initialization + sync flow makes icon insertion resilient to those timing differences.

The Pixi migration was requested in the task context so contributors can bootstrap the project with a consistent toolchain while keeping caches and dependency artifacts inside the repository directory.

## Implementation Notes
- The functional fix is intentionally focused on lifecycle and mounting reliability, without changing the core numbering logic.
- The retry-based sync is bounded and cleaned up on plugin unload.
- Build and lint commands are now expected to run through Pixi tasks (`pixi run ...`).

Fixes #21
