### PR TITLE
Fix heading numbering instability and preserve manual prefixes (issues #22-#25)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,18 @@ import { Plugin, Setting, showMessage } from "siyuan";
 import { setCursorToEnd } from "./utils/dom_operate";
 import { IPluginConfig } from "./types";
 import {
+    addAutoNumberMarker,
+    extractAutoNumberMarkerInfo,
+    extractLegacyAutoNumberPrefix,
     generateHeaderNumber,
-    getHeaderLevel,
-    hasHeaderNumber,
-    removeHeaderNumber,
+    stripAutoNumberMarker,
 } from "./utils/header_utils";
-import { batchUpdateBlockContent, getVersion } from "./utils/api";
+import {
+    batchUpdateBlockContent,
+    getDocHeadingBlocks,
+    getVersion,
+    IDocHeadingBlock,
+} from "./utils/api";
 import "./style.scss";
 
 // 存储配置的键名
@@ -454,9 +460,23 @@ export default class HeaderNumberPlugin extends Plugin {
         return protyle?.background.ial.id || null;
     }
 
-    private getHeaderElements(protyle: any): NodeListOf<Element> {
-        const wysiwyg = protyle.wysiwyg.element;
-        return wysiwyg.querySelectorAll('[data-type="NodeHeading"]');
+    private getHeadingLevelFromSubtype(subtype: string): number {
+        const matched = subtype.match(/^h([1-6])$/);
+        if (!matched) {
+            return 0;
+        }
+
+        return Number(matched[1]);
+    }
+
+    private getExistingLevelsByHeadings(headings: IDocHeadingBlock[]): number[] {
+        return Array.from(
+            new Set(
+                headings
+                    .map((heading) => this.getHeadingLevelFromSubtype(heading.subtype))
+                    .filter((level) => level > 0)
+            )
+        ).sort((a, b) => a - b);
     }
 
     private async updateDocNumbering(protyle: any) {
@@ -466,37 +486,22 @@ export default class HeaderNumberPlugin extends Plugin {
         this.removeTimer();
 
         try {
-            // 先清除所有现有的编号
-            await this.clearDocNumbering(protyle);
-            
-            // 获取所有标题元素
-            const headerElements = this.getHeaderElements(protyle);
-            if (!headerElements.length) return;
+            const headings = await getDocHeadingBlocks(docId);
+            if (!headings.length) {
+                this.shouldUpdate = false;
+                return;
+            }
 
-            // 准备更新
-            const updates: Record<string, string> = {};
+            const existingLevels = this.getExistingLevelsByHeadings(headings);
             const counters = [0, 0, 0, 0, 0, 0];
+            const updates: Record<string, string> = {};
 
-            // 处理每个标题
-            for (const element of headerElements) {
-                const blockId = element.getAttribute("data-node-id");
-                if (!blockId) continue;
+            for (const heading of headings) {
+                const level = this.getHeadingLevelFromSubtype(heading.subtype);
+                if (level === 0) {
+                    continue;
+                }
 
-                const level = getHeaderLevel(element);
-                if (level === 0) continue;
-
-                const eleWithContent = element.querySelector(
-                    '[contenteditable="true"]'
-                );
-                if (!eleWithContent) continue;
-
-                // 获取原始HTML内容而不是纯文本
-                const htmlContent = eleWithContent.innerHTML || "";
-
-                // 由于已经清除了编号，不需要再检查和移除
-                const originalContent = htmlContent;
-
-                // 生成新序号
                 const [number, newCounters] = generateHeaderNumber(
                     level,
                     counters,
@@ -504,35 +509,37 @@ export default class HeaderNumberPlugin extends Plugin {
                     this.config.useChineseNumbers,
                     existingLevels
                 );
-
-                // 更新计数器
                 Object.assign(counters, newCounters);
 
-                // 添加新序号到HTML内容
-                eleWithContent.innerHTML = number + originalContent;
+                const markerInfo = extractAutoNumberMarkerInfo(heading.markdown);
+                const restoredContent = markerInfo
+                    ? markerInfo.backupPrefix + markerInfo.content
+                    : heading.markdown;
 
-                // 添加新序号
-                updates[blockId] = element.outerHTML;
+                let backupPrefix = markerInfo?.backupPrefix || "";
+                if (!backupPrefix) {
+                    backupPrefix = extractLegacyAutoNumberPrefix(
+                        restoredContent,
+                        number
+                    );
+                }
+                const contentWithoutPrefix = backupPrefix
+                    ? restoredContent.substring(backupPrefix.length)
+                    : restoredContent;
+
+                updates[heading.id] =
+                    addAutoNumberMarker(number, backupPrefix) + contentWithoutPrefix;
             }
 
             this.changeDocEnableStatus(true);
 
-            // 批量更新内容
             if (Object.keys(updates).length > 0) {
-                // 由于是从 DOM 中获取的内容，使用 dom 格式更新
-                await batchUpdateBlockContent(updates, "dom", this.canUseBulkApi());
-
-                // 如果有活动的块，将光标移动到其末尾
-                if (this.activeBlockId) {
-                    setTimeout(() => {
-                        const activeBlock = document.querySelector(
-                            `[data-node-id="${this.activeBlockId}"]`
-                        );
-                        if (activeBlock) {
-                            setCursorToEnd(activeBlock);
-                        }
-                    }, 200);
-                }
+                await batchUpdateBlockContent(
+                    updates,
+                    "markdown",
+                    this.canUseBulkApi()
+                );
+                this.resetActiveBlockCursor();
             }
 
             this.shouldUpdate = false;
@@ -547,54 +554,27 @@ export default class HeaderNumberPlugin extends Plugin {
         if (!docId) return;
 
         try {
-            // 获取所有标题元素
-            const headerElements = this.getHeaderElements(protyle);
-            if (!headerElements.length) return;
+            const headings = await getDocHeadingBlocks(docId);
+            if (!headings.length) {
+                return;
+            }
 
-            // 准备更新
             const updates: Record<string, string> = {};
-
-            // 处理每个标题
-            for (const element of headerElements) {
-                const blockId = element.getAttribute("data-node-id");
-                if (!blockId) continue;
-
-                const level = getHeaderLevel(element);
-                if (level === 0) continue;
-
-                const eleWithContent = element.querySelector(
-                    '[contenteditable="true"]'
-                );
-                if (!eleWithContent) continue;
-
-                // 获取原始HTML内容而不是纯文本
-                const htmlContent = eleWithContent.innerHTML || "";
-
-                // 检查所有可能的格式
-                let contentUpdated = false;
-                for (let i = 0; i < this.config.formats.length; i++) {
-                    const format = this.config.formats[i];
-                    if (hasHeaderNumber(htmlContent, format)) {
-                        const originalContent = removeHeaderNumber(
-                            htmlContent,
-                            format
-                        );
-                        eleWithContent.innerHTML = originalContent;
-                        contentUpdated = true;
-                    }
-                }
-
-                // 如果内容被更新，则添加到更新列表中
-                if (contentUpdated) {
-                    updates[blockId] = element.outerHTML;
+            for (const heading of headings) {
+                const restored = stripAutoNumberMarker(heading.markdown, true);
+                if (restored !== heading.markdown) {
+                    updates[heading.id] = restored;
                 }
             }
 
             this.changeDocEnableStatus(false);
 
-            // 批量更新内容
             if (Object.keys(updates).length > 0) {
-                await batchUpdateBlockContent(updates, "dom", this.canUseBulkApi());
+                await batchUpdateBlockContent(
+                    updates,
+                    "markdown",
+                    this.canUseBulkApi()
+                );
             }
         } catch (error) {
             console.error(this.i18n.clearError, error);
@@ -606,6 +586,21 @@ export default class HeaderNumberPlugin extends Plugin {
         if (this.updateTimer) {
             clearTimeout(this.updateTimer);
         }
+    }
+
+    private resetActiveBlockCursor() {
+        if (!this.activeBlockId) {
+            return;
+        }
+
+        setTimeout(() => {
+            const activeBlock = document.querySelector(
+                `[data-node-id="${this.activeBlockId}"]`
+            );
+            if (activeBlock) {
+                setCursorToEnd(activeBlock);
+            }
+        }, 200);
     }
 
     private canUseBulkApi() {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -2,6 +2,71 @@
  * 思源笔记API工具函数
  */
 
+interface IApiResponse<T> {
+    code: number;
+    msg: string;
+    data: T;
+}
+
+export interface IDocHeadingBlock {
+    id: string;
+    markdown: string;
+    subtype: string;
+}
+
+async function postApi<T>(url: string, body: Record<string, unknown>): Promise<T> {
+    const response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+        throw new Error(`请求失败: ${url}`);
+    }
+
+    const result = (await response.json()) as IApiResponse<T>;
+    if (result.code !== 0) {
+        throw new Error(result.msg || `接口返回错误: ${url}`);
+    }
+
+    return result.data;
+}
+
+function escapeSqlValue(value: string): string {
+    return value.replace(/'/g, "''");
+}
+
+/**
+ * 获取文档中的全部标题块（不依赖当前是否懒加载到DOM）
+ */
+export async function getDocHeadingBlocks(docId: string): Promise<IDocHeadingBlock[]> {
+    const safeDocId = escapeSqlValue(docId);
+    const stmt =
+        "SELECT id, markdown, subtype FROM blocks " +
+        `WHERE root_id = '${safeDocId}' AND type = 'h' ORDER BY sort ASC`;
+
+    const data = await postApi<
+        Array<Partial<IDocHeadingBlock> & { id?: string; markdown?: string; subtype?: string }>
+    >("/api/query/sql", { stmt });
+
+    return data
+        .filter((row) => {
+            return (
+                typeof row.id === "string" &&
+                typeof row.markdown === "string" &&
+                typeof row.subtype === "string"
+            );
+        })
+        .map((row) => {
+            return {
+                id: row.id as string,
+                markdown: row.markdown as string,
+                subtype: row.subtype as string,
+            };
+        });
+}
+
 /**
  * 批量更新块内容
  * @param contents 块ID到内容的映射
@@ -10,25 +75,25 @@
 export async function batchUpdateBlockContent(
     contents: Record<string, string>,
     dataType: "dom" | "markdown" = "dom",
-    useBulkApi: boolean = false
+    useBulkApi = false
 ): Promise<void> {
     if (useBulkApi) {
         const toUpdateList = Object.entries(contents).map(([id, content]) => {
             return {
                 id,
                 data: content,
-                dataType
-            }
-        })
-        return fetch('/api/block/batchUpdateBlock', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+                dataType,
+            };
+        });
+        return fetch("/api/block/batchUpdateBlock", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
-                blocks: toUpdateList
-            })
+                blocks: toUpdateList,
+            }),
         }).then(async response => {
             if (!response.ok) {
-                throw new Error(`更新失败`);
+                throw new Error("更新失败");
             }
             return response.json();
         });
@@ -36,14 +101,14 @@ export async function batchUpdateBlockContent(
     else {
         // 为每个块创建独立的更新请求
         const updatePromises = Object.entries(contents).map(([id, content]) => {
-            return fetch('/api/block/updateBlock', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+            return fetch("/api/block/updateBlock", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({
                     id,
                     data: content,
-                    dataType
-                })
+                    dataType,
+                }),
             }).then(async response => {
                 if (!response.ok) {
                     throw new Error(`更新块 ${id} 失败`);
@@ -56,19 +121,19 @@ export async function batchUpdateBlockContent(
             // 并行执行所有更新请求
             await Promise.all(updatePromises);
         } catch (error: unknown) {
-            const errorMessage = error instanceof Error ? error.message : '未知错误';
+            const errorMessage = error instanceof Error ? error.message : "未知错误";
             throw new Error(`批量更新块内容失败: ${errorMessage}`);
         }
     }
 }
 
 export async function getVersion(): Promise<string> {
-    return fetch('/api/system/version', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+    return fetch("/api/system/version", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
     }).then(async response => {
         if (!response.ok) {
-            throw new Error(`获取版本号失败`);
+            throw new Error("获取版本号失败");
         }
         const data = await response.json();
         return data.data;

--- a/src/utils/header_utils.ts
+++ b/src/utils/header_utils.ts
@@ -1,20 +1,134 @@
+const AUTO_NUMBER_MARKER_START = "\u2063\u2064\u2063";
+const AUTO_NUMBER_MARKER_END = "\u2064\u2063\u2064";
+const HIDDEN_ZERO = "\u200b";
+const HIDDEN_ONE = "\u200c";
+const HIDDEN_SEPARATOR = "\u200d";
+
+interface IAutoMarkerPayload {
+    backupPrefix: string;
+    number: string;
+}
+
+export interface IAutoNumberMarkerInfo {
+    backupPrefix: string;
+    number: string;
+    content: string;
+}
+
+function encodeHiddenText(text: string): string {
+    return text
+        .split("")
+        .map((character) => {
+            return character
+                .charCodeAt(0)
+                .toString(2)
+                .padStart(16, "0")
+                .replace(/0/g, HIDDEN_ZERO)
+                .replace(/1/g, HIDDEN_ONE);
+        })
+        .join(HIDDEN_SEPARATOR);
+}
+
+function decodeHiddenText(text: string): string | null {
+    if (!text) {
+        return "";
+    }
+
+    const chunks = text.split(HIDDEN_SEPARATOR);
+    const hiddenChunkPattern = new RegExp(`^[${HIDDEN_ZERO}${HIDDEN_ONE}]{16}$`);
+
+    let decoded = "";
+    for (const chunk of chunks) {
+        if (!hiddenChunkPattern.test(chunk)) {
+            return null;
+        }
+
+        const binary = chunk
+            .split("")
+            .map((char) => {
+                if (char === HIDDEN_ZERO) {
+                    return "0";
+                }
+                if (char === HIDDEN_ONE) {
+                    return "1";
+                }
+                return "";
+            })
+            .join("");
+
+        if (binary.length !== 16) {
+            return null;
+        }
+
+        decoded += String.fromCharCode(parseInt(binary, 2));
+    }
+
+    return decoded;
+}
+
+function parseMarker(text: string): {
+    payload: IAutoMarkerPayload;
+    markerEndIndex: number;
+} | null {
+    if (!text.startsWith(AUTO_NUMBER_MARKER_START)) {
+        return null;
+    }
+
+    const markerEndIndex = text.indexOf(
+        AUTO_NUMBER_MARKER_END,
+        AUTO_NUMBER_MARKER_START.length
+    );
+    if (markerEndIndex === -1) {
+        return null;
+    }
+
+    const encodedPayload = text.substring(
+        AUTO_NUMBER_MARKER_START.length,
+        markerEndIndex
+    );
+    const decodedPayload = decodeHiddenText(encodedPayload);
+    if (decodedPayload === null) {
+        return null;
+    }
+
+    try {
+        const payload = JSON.parse(decodedPayload) as Partial<IAutoMarkerPayload>;
+        if (
+            typeof payload.backupPrefix !== "string" ||
+            typeof payload.number !== "string"
+        ) {
+            return null;
+        }
+
+        return {
+            payload: {
+                backupPrefix: payload.backupPrefix,
+                number: payload.number,
+            },
+            markerEndIndex,
+        };
+    } catch {
+        return null;
+    }
+}
+
 /**
  * 将数字转换为中文数字
  * @param num 要转换的数字
  * @returns 转换后的中文数字
  */
 export function num2Chinese(num: number): string {
-    const units = ['', '十', '百', '千', '万'];
-    const numbers = ['零', '一', '二', '三', '四', '五', '六', '七', '八', '九'];
-    
+    const units = ["", "十", "百", "千", "万"];
+    const numbers = ["零", "一", "二", "三", "四", "五", "六", "七", "八", "九"];
+
     if (num === 0) return numbers[0];
-    if (num < 0) return '负' + num2Chinese(-num);
+    if (num < 0) return "负" + num2Chinese(-num);
     if (num < 10) return numbers[num];
-    
-    let result = '';
+
+    let result = "";
     let temp = num;
     let unitIndex = 0;
-    
+
     while (temp > 0) {
         const digit = temp % 10;
         if (digit === 0) {
@@ -27,17 +141,126 @@ export function num2Chinese(num: number): string {
         temp = Math.floor(temp / 10);
         unitIndex++;
     }
-    
-    // 处理特殊情况
-    result = result.replace(/零+$/, ''); // 移除末尾的零
-    result = result.replace(/零+/g, '零'); // 多个零合并为一个
-    
-    // 处理"一十"开头的情况
-    if (result.startsWith('一十')) {
+
+    result = result.replace(/零+$/, "");
+    result = result.replace(/零+/g, "零");
+
+    if (result.startsWith("一十")) {
         result = result.substring(1);
     }
-    
+
     return result;
+}
+
+/**
+ * 为自动序号添加隐藏标记，仅用于插件识别与移除
+ */
+export function addAutoNumberMarker(number: string, backupPrefix = ""): string {
+    const encodedPayload = encodeHiddenText(
+        JSON.stringify({
+            backupPrefix,
+            number,
+        })
+    );
+    return `${AUTO_NUMBER_MARKER_START}${encodedPayload}${AUTO_NUMBER_MARKER_END}${number}`;
+}
+
+/**
+ * 提取自动序号标记信息
+ */
+export function extractAutoNumberMarkerInfo(text: string): IAutoNumberMarkerInfo | null {
+    const marker = parseMarker(text);
+    if (!marker) {
+        return null;
+    }
+
+    const afterMarker = text.substring(
+        marker.markerEndIndex + AUTO_NUMBER_MARKER_END.length
+    );
+    const content =
+        marker.payload.number && afterMarker.startsWith(marker.payload.number)
+            ? afterMarker.substring(marker.payload.number.length)
+            : afterMarker;
+
+    return {
+        backupPrefix: marker.payload.backupPrefix,
+        number: marker.payload.number,
+        content,
+    };
+}
+
+/**
+ * 移除插件自动添加的隐藏标记与对应序号，不影响用户手动输入内容
+ */
+export function stripAutoNumberMarker(
+    text: string,
+    restoreBackupPrefix = false
+): string {
+    const markerInfo = extractAutoNumberMarkerInfo(text);
+    if (!markerInfo) {
+        return text;
+    }
+
+    const prefix = restoreBackupPrefix ? markerInfo.backupPrefix : "";
+    return `${prefix}${markerInfo.content}`;
+}
+
+function buildLegacyNumberCandidates(number: string): string[] {
+    const candidateSet = new Set<string>();
+    const trimmed = number.replace(/\s+$/, "");
+
+    if (number) {
+        candidateSet.add(number);
+    }
+    if (trimmed) {
+        candidateSet.add(trimmed);
+        candidateSet.add(`${trimmed} `);
+    }
+
+    if (/[.。．、,，:：;；]$/.test(trimmed)) {
+        const withoutTail = trimmed.slice(0, -1);
+        if (withoutTail) {
+            candidateSet.add(withoutTail);
+            candidateSet.add(`${withoutTail} `);
+        }
+    }
+
+    return Array.from(candidateSet).sort((a, b) => b.length - a.length);
+}
+
+/**
+ * 从内容前缀中识别兼容旧版本的自动序号
+ */
+export function extractLegacyAutoNumberPrefix(
+    text: string,
+    generatedNumber: string
+): string {
+    if (!text || !generatedNumber) {
+        return "";
+    }
+
+    const candidates = buildLegacyNumberCandidates(generatedNumber);
+
+    for (const candidate of candidates) {
+        if (!candidate || !text.startsWith(candidate)) {
+            continue;
+        }
+
+        const rest = text.substring(candidate.length);
+        const punctuationMatch = rest.match(/^[.。．、,，:：;；]+\s*/);
+        if (punctuationMatch) {
+            return candidate + punctuationMatch[0];
+        }
+
+        const trailingSpaceMatch = rest.match(/^\s+/);
+        if (trailingSpaceMatch) {
+            return candidate + trailingSpaceMatch[0];
+        }
+
+        return candidate;
+    }
+
+    return "";
 }
 
 /**
@@ -47,7 +270,12 @@ export function num2Chinese(num: number): string {
  * @returns 实际层级（0-based）
  */
 function getActualHeaderLevel(level: number, existingLevels: number[]): number {
-    return existingLevels.indexOf(level);
+    const index = existingLevels.indexOf(level);
+    if (index !== -1) {
+        return index;
+    }
+
+    return Math.max(0, Math.min(level - 1, 5));
 }
 
 /**
@@ -66,40 +294,34 @@ export function generateHeaderNumber(
     useChineseNumbers: boolean[],
     existingLevels: number[] = []
 ): [string, number[]] {
-    // 获取实际层级
-    const actualLevel = existingLevels.length > 0 ? getActualHeaderLevel(level, existingLevels) : level - 1;
-    
-    // 复制计数器以避免修改原数组
+    const actualLevel =
+        existingLevels.length > 0
+            ? getActualHeaderLevel(level, existingLevels)
+            : Math.max(0, Math.min(level - 1, 5));
+
     const newCounters = [...counters];
-    
-    // 增加当前级别的计数
     newCounters[actualLevel]++;
-    
-    // 重置所有低级别的计数
+
     for (let i = actualLevel + 1; i < newCounters.length; i++) {
         newCounters[i] = 0;
     }
-    
-    // 获取当前级别的格式
-    const format = formats[actualLevel];
-    
-    // 生成序号
+
+    const format = formats[actualLevel] ?? formats[formats.length - 1] ?? "{1}. ";
+
     let result = format;
-    // 找出所有占位符
     const placeholders = format.match(/\{(\d+)\}/g) || [];
-    
+
     for (const placeholder of placeholders) {
-        // 获取占位符中的数字
         const match = placeholder.match(/\{(\d+)\}/);
         if (!match) continue;
+
         const index = parseInt(match[1]) - 1;
-        // 使用当前标题级别的 useChineseNumbers 设置
         const shouldUseChinese = useChineseNumbers[actualLevel];
         const num = newCounters[index];
         const numStr = shouldUseChinese ? num2Chinese(num) : num.toString();
         result = result.replace(placeholder, numStr);
     }
-    
+
     return [result, newCounters];
 }
 
@@ -110,33 +332,29 @@ export function generateHeaderNumber(
  * @returns 如果包含序号返回true，否则返回false
  */
 export function hasHeaderNumber(text: string, format: string): boolean {
-    // 找出所有占位符
     const placeholders = format.match(/\{(\d+)\}/g) || [];
     let regexPattern = format;
-    
-    // 先替换占位符为临时标记，避免被转义
+
     const tempMarkers: string[] = [];
     placeholders.forEach((placeholder, index) => {
         const marker = `__PLACEHOLDER_${index}__`;
         tempMarkers.push(marker);
         regexPattern = regexPattern.replace(placeholder, marker);
     });
-    
-    // 转义正则表达式特殊字符
-    regexPattern = regexPattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    
-    // 还原占位符并替换为数字匹配模式
+
+    regexPattern = regexPattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
     tempMarkers.forEach((marker) => {
-        const numbers = ['0']; // 添加0作为可能的数字
+        const numbers = ["0"];
         for (let i = 1; i <= 99; i++) {
             numbers.push(i.toString(), num2Chinese(i));
         }
         regexPattern = regexPattern.replace(
             marker,
-            `(${numbers.map(n => n.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})`
+            `(${numbers.map((n) => n.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")})`
         );
     });
-    
+
     const regex = new RegExp(`^${regexPattern}`);
     return regex.test(text);
 }
@@ -148,35 +366,31 @@ export function hasHeaderNumber(text: string, format: string): boolean {
  * @returns 移除序号后的文本
  */
 export function removeHeaderNumber(text: string, format: string): string {
-    // 找出所有占位符
     const placeholders = format.match(/\{(\d+)\}/g) || [];
     let regexPattern = format;
-    
-    // 先替换占位符为临时标记，避免被转义
+
     const tempMarkers: string[] = [];
     placeholders.forEach((placeholder, index) => {
         const marker = `__PLACEHOLDER_${index}__`;
         tempMarkers.push(marker);
         regexPattern = regexPattern.replace(placeholder, marker);
     });
-    
-    // 转义正则表达式特殊字符
-    regexPattern = regexPattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    
-    // 还原占位符并替换为数字匹配模式
+
+    regexPattern = regexPattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
     tempMarkers.forEach((marker) => {
-        const numbers = ['0']; // 添加0作为可能的数字
+        const numbers = ["0"];
         for (let i = 1; i <= 99; i++) {
             numbers.push(i.toString(), num2Chinese(i));
         }
         regexPattern = regexPattern.replace(
             marker,
-            `(${numbers.map(n => n.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})`
+            `(${numbers.map((n) => n.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")})`
         );
     });
-    
+
     const regex = new RegExp(`^${regexPattern}`);
-    return text.replace(regex, '');
+    return text.replace(regex, "");
 }
 
 /**
@@ -191,4 +405,4 @@ export function getHeaderLevel(element: Element): number {
         }
     }
     return 0;
-} 
+}


### PR DESCRIPTION
## Summary
This PR fixes a shared root cause behind issues #22, #23, #24, and #25.

Previously, heading numbering was derived from the currently mounted editor DOM and removed via format-based regex matching. That combination was fragile:
- lazy-loaded documents could be renumbered from only a partial heading set,
- format changes could leave old prefixes and add new ones,
- disabling numbering could remove user-authored/manual heading prefixes.

## What changed
- Added `getDocHeadingBlocks` in `src/utils/api.ts` to load **all heading blocks for the current document** (`id`, `markdown`, `subtype`) from the database (`blocks`) in `sort` order.
- Reworked numbering in `src/index.ts` to renumber from the full heading list instead of visible DOM nodes.
- Switched update/clear writes to `markdown` block updates (instead of DOM HTML updates) for consistent data-level behavior.
- Introduced marker-based auto-number tracking in `src/utils/header_utils.ts`:
  - `addAutoNumberMarker`
  - `extractAutoNumberMarkerInfo`
  - `stripAutoNumberMarker`
- Added legacy prefix compatibility via `extractLegacyAutoNumberPrefix` to safely handle old/generated prefixes when users change numbering formats.
- Hardened `generateHeaderNumber` level fallback logic to avoid invalid level indexing and unstable numbering edge cases.

## Why these changes
These changes target the exact symptoms reported in the task context:
- **#22**: Prevent duplicate prefixes after format changes.
- **#23 / #24**: Eliminate inconsistent/partial numbering caused by lazy loading and incomplete DOM state.
- **#25**: Ensure disabling the plugin only removes plugin-generated numbering and does not erase user-defined/manual prefixes.

## Important implementation details
- Auto-generated numbers are tagged with an invisible marker payload (including generated number + backup prefix), so clearing can be precise and reversible.
- Renumbering now always uses a full-document heading snapshot, then applies ordered batch updates.
- Cursor restoration for the active block is preserved after updates to reduce editing disruption.
