### PR TITLE
Fix auto-number cleanup and counter drift for issue #25

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -485,22 +485,14 @@ export default class HeaderNumberPlugin extends Plugin {
 
     private splitHeadingMarkdown(
         markdown: string
-    ): { prefix: string; content: string } {
+    ): { prefix: string; content: string } | null {
         const directParts = splitMarkdownHeading(markdown);
         if (directParts) {
             return directParts;
         }
 
         const restoredMarkdown = stripAutoNumberMarker(markdown, true);
-        const restoredParts = splitMarkdownHeading(restoredMarkdown);
-        if (restoredParts) {
-            return restoredParts;
-        }
-
-        return {
-            prefix: "",
-            content: markdown,
-        };
+        return splitMarkdownHeading(restoredMarkdown);
     }
 
     private async updateDocNumbering(protyle: any) {
@@ -526,6 +518,11 @@ export default class HeaderNumberPlugin extends Plugin {
                     continue;
                 }
 
+                const headingParts = this.splitHeadingMarkdown(heading.markdown);
+                if (!headingParts) {
+                    continue;
+                }
+
                 const [number, newCounters] = generateHeaderNumber(
                     level,
                     counters,
@@ -533,9 +530,7 @@ export default class HeaderNumberPlugin extends Plugin {
                     this.config.useChineseNumbers,
                     existingLevels
                 );
-                Object.assign(counters, newCounters);
 
-                const headingParts = this.splitHeadingMarkdown(heading.markdown);
                 const headingPrefix = headingParts.prefix;
                 const headingContent = headingParts.content;
 
@@ -558,6 +553,8 @@ export default class HeaderNumberPlugin extends Plugin {
                 updates[heading.id] =
                     `${headingPrefix}${addAutoNumberMarker(number, backupPrefix)}` +
                     contentWithoutPrefix;
+
+                Object.assign(counters, newCounters);
             }
 
             this.changeDocEnableStatus(true);

--- a/src/utils/header_utils.ts
+++ b/src/utils/header_utils.ts
@@ -21,6 +21,11 @@ export interface IAutoNumberMarkerInfo {
     content: string;
 }
 
+interface ITextWithoutAutoNumber {
+    beforeContent: string;
+    afterContent: string;
+}
+
 function encodeHiddenText(text: string): string {
     return text
         .split("")
@@ -168,7 +173,40 @@ export function addAutoNumberMarker(number: string, backupPrefix = ""): string {
             number,
         })
     );
-    return `${AUTO_NUMBER_MARKER_START}${encodedPayload}${AUTO_NUMBER_MARKER_END}${number}`;
+    return `${number}${AUTO_NUMBER_MARKER_START}${encodedPayload}${AUTO_NUMBER_MARKER_END}`;
+}
+
+function removeAutoNumberNearMarker(
+    text: string,
+    marker: IParsedMarker
+): ITextWithoutAutoNumber {
+    const beforeMarker = text.substring(0, marker.markerStartIndex);
+    const afterMarker = text.substring(
+        marker.markerEndIndex + AUTO_NUMBER_MARKER_END.length
+    );
+    const markerNumber = marker.payload.number;
+
+    if (markerNumber && afterMarker.startsWith(markerNumber)) {
+        return {
+            beforeContent: beforeMarker,
+            afterContent: afterMarker.substring(markerNumber.length),
+        };
+    }
+
+    if (markerNumber && beforeMarker.endsWith(markerNumber)) {
+        return {
+            beforeContent: beforeMarker.substring(
+                0,
+                beforeMarker.length - markerNumber.length
+            ),
+            afterContent: afterMarker,
+        };
+    }
+
+    return {
+        beforeContent: beforeMarker,
+        afterContent: afterMarker,
+    };
 }
 
 /**
@@ -180,19 +218,12 @@ export function extractAutoNumberMarkerInfo(text: string): IAutoNumberMarkerInfo
         return null;
     }
 
-    const beforeMarker = text.substring(0, marker.markerStartIndex);
-    const afterMarker = text.substring(
-        marker.markerEndIndex + AUTO_NUMBER_MARKER_END.length
-    );
-    const contentAfterNumber =
-        marker.payload.number && afterMarker.startsWith(marker.payload.number)
-            ? afterMarker.substring(marker.payload.number.length)
-            : afterMarker;
+    const { beforeContent, afterContent } = removeAutoNumberNearMarker(text, marker);
 
     return {
         backupPrefix: marker.payload.backupPrefix,
         number: marker.payload.number,
-        content: `${beforeMarker}${contentAfterNumber}`,
+        content: `${beforeContent}${afterContent}`,
     };
 }
 
@@ -208,17 +239,10 @@ export function stripAutoNumberMarker(
         return text;
     }
 
-    const beforeMarker = text.substring(0, marker.markerStartIndex);
-    const afterMarker = text.substring(
-        marker.markerEndIndex + AUTO_NUMBER_MARKER_END.length
-    );
-    const contentAfterNumber =
-        marker.payload.number && afterMarker.startsWith(marker.payload.number)
-            ? afterMarker.substring(marker.payload.number.length)
-            : afterMarker;
+    const { beforeContent, afterContent } = removeAutoNumberNearMarker(text, marker);
     const backupPrefix = restoreBackupPrefix ? marker.payload.backupPrefix : "";
 
-    return `${beforeMarker}${backupPrefix}${contentAfterNumber}`;
+    return `${beforeContent}${backupPrefix}${afterContent}`;
 }
 
 interface IMarkdownHeadingParts {


### PR DESCRIPTION
## Summary
This PR addresses follow-up regressions reported in issue #25 after the heading marker placement fix.

## What changed
- Updated heading parsing in `src/index.ts`:
  - `splitHeadingMarkdown` now returns `null` when a heading cannot be parsed, instead of forcing a fallback shape.
  - Number generation now runs only for valid headings, and counter state is updated only after a heading update is actually applied.
- Refined auto-number marker behavior in `src/utils/header_utils.ts`:
  - `addAutoNumberMarker` now emits `number + hidden-marker` (instead of `hidden-marker + number`) to keep number removal predictable.
  - Added `removeAutoNumberNearMarker` to remove auto numbers adjacent to a marker from either side.
  - `extractAutoNumberMarkerInfo` and `stripAutoNumberMarker` now share the same removal logic to support both old and new marker layouts.

## Why these changes were needed
Users reported three problems in the same flow:
1. Disabling auto numbering did not remove the visible sequence numbers.
2. Re-enabling auto numbering caused duplicated numbers.
3. Some documents started H1 numbering from "3" instead of "1".

The root causes were:
- Marker cleanup logic only removed numbers in one marker layout direction.
- Counter increments could still happen for malformed/unrecoverable heading markdown entries, causing drift.

## Important implementation details
- Cleanup is backward-compatible: both legacy (`marker + number`) and current (`number + marker`) content are handled.
- Heading counters now advance only when the heading is parseable and a concrete update is produced.
- The fix is intentionally scoped to numbering state/marker extraction logic; format customization behavior is unchanged.
