### PR TITLE
Add configurable prefix cleanup when disabling auto-numbering

### DIFF
--- a/src/i18n/en_US.json
+++ b/src/i18n/en_US.json
@@ -18,5 +18,7 @@
     "updateError": "Error updating header numbers",
     "updateErrorMsg": "Failed to update header numbers",
     "clearError": "Error clearing header numbers",
-    "clearErrorMsg": "Failed to clear header numbers"
+    "clearErrorMsg": "Failed to clear header numbers",
+    "preservePrefixOnDisable": "Preserve Prefix on Disable",
+    "preservePrefixOnDisableDesc": "When disabling auto-numbering, keep previously detected heading prefixes (such as manual numbering)"
 }

--- a/src/i18n/zh_CN.json
+++ b/src/i18n/zh_CN.json
@@ -18,5 +18,7 @@
     "updateError": "更新标题序号时出错",
     "updateErrorMsg": "更新标题序号失败",
     "clearError": "清除标题序号时出错",
-    "clearErrorMsg": "清除标题序号失败"
+    "clearErrorMsg": "清除标题序号失败",
+    "preservePrefixOnDisable": "关闭时保留原前缀",
+    "preservePrefixOnDisableDesc": "关闭自动编号时，是否保留之前识别到的标题前缀（如手动编号）"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ const DEFAULT_CONFIG: IPluginConfig = {
     defaultEnabled: true,
     realTimeUpdate: false,
     docEnableStatus: {},
+    preservePrefixOnDisable: true,
 };
 
 const TOP_BAR_ICON_SVG =
@@ -110,6 +111,27 @@ export default class HeaderNumberPlugin extends Plugin {
                             clearTimeout(this.updateTimer);
                         }
                     }
+                });
+
+                container.appendChild(checkbox);
+                return container;
+            },
+        });
+
+        // 添加关闭时保留前缀设置
+        this.setting.addItem({
+            title: this.i18n.preservePrefixOnDisable,
+            description: this.i18n.preservePrefixOnDisableDesc,
+            createActionElement: () => {
+                const container = document.createElement("div");
+                container.className = "setting-item__action";
+
+                const checkbox = document.createElement("input");
+                checkbox.type = "checkbox";
+                checkbox.className = "b3-switch fn__flex-center";
+                checkbox.checked = this.config.preservePrefixOnDisable;
+                checkbox.addEventListener("change", () => {
+                    this.config.preservePrefixOnDisable = checkbox.checked;
                 });
 
                 container.appendChild(checkbox);
@@ -206,6 +228,7 @@ export default class HeaderNumberPlugin extends Plugin {
                         realTimeUpdate: false,
                         docEnableStatus:
                             this.data[STORAGE_NAME].docEnableStatus, //不删除保存的单独文档设置
+                        preservePrefixOnDisable: true,
                     };
                     await this.saveConfig();
                     showMessage(this.i18n.settingsResetSuccess);
@@ -571,7 +594,10 @@ export default class HeaderNumberPlugin extends Plugin {
 
             const updates: Record<string, string> = {};
             for (const heading of headings) {
-                const restored = stripAutoNumberMarker(heading.markdown, true);
+                const restored = stripAutoNumberMarker(
+                    heading.markdown,
+                    this.config.preservePrefixOnDisable
+                );
                 if (restored !== heading.markdown) {
                     updates[heading.id] = restored;
                 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,8 @@ export interface IPluginConfig {
     realTimeUpdate: boolean;
     // 每个文档的启用状态
     docEnableStatus: Record<string, boolean>;
+    // 关闭自动编号时是否保留历史前缀
+    preservePrefixOnDisable: boolean;
 }
 
 /**

--- a/tests/header_utils.test.ts
+++ b/tests/header_utils.test.ts
@@ -150,3 +150,31 @@ test("renumberHeadings should stay stable after clear and reapply with mixed hea
     assert.deepEqual(secondRound, firstRound);
 });
 
+test("buildAutoNumberedHeadingContent should keep full Chinese heading text when first enabling numbering", () => {
+    const renumbered = buildAutoNumberedHeadingContent("开启自动序号", "1. ", true);
+
+    assert.equal(stripAutoNumberMarker(renumbered, true), "开启自动序号");
+    assert.equal(stripAutoNumberMarker(renumbered, false), "开启自动序号");
+});
+
+test("renumberHeadings should recompute order after clear-without-prefix mode and manual reorder", () => {
+    const source = [
+        { level: 1, markdown: "# 测试1" },
+        { level: 1, markdown: "# 测试2" },
+    ];
+
+    const firstRound = renumberHeadings(source);
+    const cleared = firstRound.map((markdown) => {
+        return stripAutoNumberMarker(markdown, false);
+    });
+
+    const secondRound = renumberHeadings([
+        { level: 1, markdown: cleared[1] },
+        { level: 1, markdown: cleared[0] },
+    ]);
+
+    assert.match(secondRound[0], /^#\s*1\.\s/);
+    assert.match(secondRound[1], /^#\s*2\.\s/);
+    assert.equal(stripAutoNumberMarker(secondRound[0], false), "# 测试2");
+    assert.equal(stripAutoNumberMarker(secondRound[1], false), "# 测试1");
+});


### PR DESCRIPTION
## Summary
This PR adds a configurable cleanup mode for disabling auto-numbering, so users can choose between preserving detected heading prefixes or removing them completely.

## Why
Recent feedback in issue #25 reported two pain points:
1. Concern about heading text/prefix integrity when toggling numbering.
2. Reordering headings after disabling numbering could feel incorrect if old prefixes remained and influenced the next numbering run.

Some users prefer strict cleanup behavior (old-style) to ensure a clean slate before re-enabling numbering, while others want to keep manually meaningful prefixes. This PR makes that behavior explicit and user-configurable.

## What Changed
- Added a new plugin config field:
  - `preservePrefixOnDisable: boolean` in `IPluginConfig`.
  - Default value is `true` for backward-compatible behavior.
- Added a new setting in the UI:
  - **Preserve Prefix on Disable**
  - Localized in both `en_US` and `zh_CN` i18n files.
- Updated disable/clear flow in `clearDocNumbering`:
  - `stripAutoNumberMarker(...)` now uses `this.config.preservePrefixOnDisable` instead of a hardcoded `true`.
- Updated reset logic to restore `preservePrefixOnDisable` to `true`.
- Added regression tests to cover the new feedback scenarios:
  - Chinese heading text is preserved when enabling numbering.
  - Numbering is recomputed correctly after “clear without prefix preservation” + manual reorder.

## Important Implementation Details
- The new option changes only the **disable/clear** phase behavior.
- Number generation/recalculation logic remains unchanged.
- This keeps compatibility for users who rely on preserved prefixes, while enabling a strict cleanup mode for users who want deterministic reordering after a full clear.

## Validation
- `node --test tests/header_utils.test.ts` (12/12 passing)
- `npx eslint src tests --max-warnings=0`
- `npm run build`
