### PR TITLE
Flush transaction queue before renumbering and default to full cleanup on disable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
 } from "./utils/header_utils";
 import {
     batchUpdateBlockContent,
+    flushTransactionQueue,
     getDocHeadingBlocks,
     getVersion,
     IDocHeadingBlock,
@@ -33,7 +34,7 @@ const DEFAULT_CONFIG: IPluginConfig = {
     defaultEnabled: true,
     realTimeUpdate: false,
     docEnableStatus: {},
-    preservePrefixOnDisable: true,
+    preservePrefixOnDisable: false,
 };
 
 const TOP_BAR_ICON_SVG =
@@ -228,7 +229,7 @@ export default class HeaderNumberPlugin extends Plugin {
                         realTimeUpdate: false,
                         docEnableStatus:
                             this.data[STORAGE_NAME].docEnableStatus, //不删除保存的单独文档设置
-                        preservePrefixOnDisable: true,
+                        preservePrefixOnDisable: false,
                     };
                     await this.saveConfig();
                     showMessage(this.i18n.settingsResetSuccess);
@@ -516,6 +517,14 @@ export default class HeaderNumberPlugin extends Plugin {
         return splitMarkdownHeading(restoredMarkdown);
     }
 
+    private async syncTransactionQueue() {
+        try {
+            await flushTransactionQueue();
+        } catch (error) {
+            console.warn("Failed to flush transaction queue before numbering", error);
+        }
+    }
+
     private async updateDocNumbering(protyle: any) {
         const docId = this.getDocId(protyle);
         if (!docId) return;
@@ -523,6 +532,7 @@ export default class HeaderNumberPlugin extends Plugin {
         this.removeTimer();
 
         try {
+            await this.syncTransactionQueue();
             const headings = await getDocHeadingBlocks(docId);
             if (!headings.length) {
                 this.shouldUpdate = false;
@@ -587,6 +597,7 @@ export default class HeaderNumberPlugin extends Plugin {
         if (!docId) return;
 
         try {
+            await this.syncTransactionQueue();
             const headings = await getDocHeadingBlocks(docId);
             if (!headings.length) {
                 return;

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -127,6 +127,11 @@ export async function batchUpdateBlockContent(
     }
 }
 
+
+export async function flushTransactionQueue(): Promise<void> {
+    await postApi<null>("/api/sqlite/flushTransaction", {});
+}
+
 export async function getVersion(): Promise<string> {
     return fetch("/api/system/version", {
         method: "POST",


### PR DESCRIPTION
## Summary
This PR addresses stale heading state during auto-numbering toggles by flushing SiYuan's transaction queue before reading heading blocks, and updates the default disable behavior to fully clear detected prefixes.

## Why
Recent user feedback (issue #25) reported that:
- heading text could appear to be lost when enabling auto-numbering immediately after typing,
- numbering order could remain outdated after reordering headings and re-enabling,
- disabling auto-numbering did not always feel like a full cleanup.

A likely root cause is reading heading data from SQL before recent editor transactions are fully flushed, which can produce stale snapshots for renumbering and cleanup.

## What Changed
- Added a new API helper in `src/utils/api.ts`:
  - `flushTransactionQueue()` → calls `/api/sqlite/flushTransaction`.
- Added a sync step in `src/index.ts`:
  - `syncTransactionQueue()` is called at the start of both
    - `updateDocNumbering(...)`
    - `clearDocNumbering(...)`
  - This ensures heading queries run on up-to-date transaction state.
- Changed default config behavior in `src/index.ts`:
  - `preservePrefixOnDisable` default changed from `true` to `false`.
  - Reset settings now also restore `preservePrefixOnDisable: false`.

## Important Implementation Details
- Queue flush is wrapped in a safe `try/catch`; numbering still proceeds if flush fails.
- This PR does not change numbering format generation logic; it improves timing consistency and disable-cleanup defaults.
- The new default (`preservePrefixOnDisable = false`) matches a stricter “clear on disable” expectation while keeping the setting configurable.
