### PR TITLE
Fix cleanup of malformed legacy heading markers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siyuan-auto-seq-number",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "A SiYuan Plugin to auto generate sequence number for headers",
   "main": ".src/index.js",
   "scripts": {

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "name": "siyuan-auto-seq-number",
   "author": "Logic Tan",
   "url": "https://github.com/dale0525/siyuan-auto-seq-number",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "minAppVersion": "3.1.25",
   "backends": [
     "all"

--- a/src/numbering/marker_codec.ts
+++ b/src/numbering/marker_codec.ts
@@ -251,3 +251,37 @@ export function stripMarker(
         result.content.slice(insertIndex)
     );
 }
+
+export function stripLegacyMarkerArtifacts(text: string): string {
+    if (!text) {
+        return text;
+    }
+
+    let cleaned = text;
+    let rounds = 0;
+
+    while (rounds < 20) {
+        const markerStartIndex = cleaned.indexOf(MARKER_START);
+        if (markerStartIndex < 0) {
+            break;
+        }
+
+        const markerEndIndex = cleaned.indexOf(
+            MARKER_END,
+            markerStartIndex + MARKER_START.length
+        );
+        if (markerEndIndex < 0) {
+            break;
+        }
+
+        cleaned =
+            cleaned.slice(0, markerStartIndex) +
+            cleaned.slice(markerEndIndex + MARKER_END.length);
+        rounds++;
+    }
+
+    return cleaned.replace(/^[\u200b-\u200d\u2063\u2064]+/u, "").replace(
+        /[\u200b-\u200d\u2063\u2064]+$/u,
+        ""
+    );
+}

--- a/src/numbering/numbering_engine.ts
+++ b/src/numbering/numbering_engine.ts
@@ -1,5 +1,10 @@
 import { splitHeadingLine } from "./heading_line";
-import { addMarker, readMarker, stripMarker } from "./marker_codec";
+import {
+    addMarker,
+    readMarker,
+    stripLegacyMarkerArtifacts,
+    stripMarker,
+} from "./marker_codec";
 import {
     buildNumberingStateAttrs,
     computeContentDigest,
@@ -449,12 +454,15 @@ export function planHeadingUpdates(
         const number = generateNumberFromFormat(format, counters, useChinese);
 
         const markerInfo = readMarker(parts.content);
+        const sanitizedContent = stripLegacyMarkerArtifacts(parts.content);
         const storedState = resolveStoredState(heading);
         const restoredState = markerInfo
             ? null
-            : restoreStoredContent(parts.content, storedState, number);
+            : restoreStoredContent(sanitizedContent, storedState, number);
         const restoredContent = markerInfo
-            ? `${markerInfo.backupPrefix}${markerInfo.content}`
+            ? stripLegacyMarkerArtifacts(
+                  `${markerInfo.backupPrefix}${markerInfo.content}`
+              )
             : restoredState.content;
         const backupPrefix =
             markerInfo?.backupPrefix ||
@@ -497,22 +505,23 @@ function clearVisibleNumberingFromAttrs(
         return heading.markdown;
     }
 
+    const sanitizedContent = stripLegacyMarkerArtifacts(parts.content);
     const visiblePrefix = extractStoredNumberPrefix(
-        parts.content,
+        sanitizedContent,
         storedState.number,
         storedState.contentDigest
     );
     const exactStoredPrefix = extractExactVisibleNumberPrefix(
-        parts.content,
+        sanitizedContent,
         storedState.number
     );
     const visibleExactPrefix = expandVisibleExactPrefix(
-        parts.content,
+        sanitizedContent,
         storedState.number,
         exactStoredPrefix
     );
     const exactContent = visibleExactPrefix
-        ? parts.content.substring(visibleExactPrefix.length)
+        ? sanitizedContent.substring(visibleExactPrefix.length)
         : "";
     const exactDigestMatches = visibleExactPrefix
         ? contentMatchesStoredDigest(exactContent, storedState.contentDigest)
@@ -523,10 +532,12 @@ function clearVisibleNumberingFromAttrs(
         : "";
     const matchedPrefix = trustedExactPrefix || visiblePrefix;
     if (!matchedPrefix) {
-        return heading.markdown;
+        return sanitizedContent === parts.content
+            ? heading.markdown
+            : `${parts.prefix}${sanitizedContent}`;
     }
 
-    const content = parts.content.substring(matchedPrefix.length);
+    const content = sanitizedContent.substring(matchedPrefix.length);
     const digestMatches =
         matchedPrefix === trustedExactPrefix
             ? exactDigestMatches
@@ -556,12 +567,29 @@ export function clearAutoNumbering(
         const restored = stripMarker(heading.markdown, {
             restorePrefix: options.preservePrefix,
         });
+        const sanitizedHeading =
+            restored === heading.markdown
+                ? heading
+                : {
+                      ...heading,
+                      markdown: restored,
+                  };
+        const markerCleanedHeading =
+            stripLegacyMarkerArtifacts(sanitizedHeading.markdown) ===
+            sanitizedHeading.markdown
+                ? sanitizedHeading
+                : {
+                      ...sanitizedHeading,
+                      markdown: stripLegacyMarkerArtifacts(sanitizedHeading.markdown),
+                  };
         const finalRestored =
-            restored !== heading.markdown
-                ? restored
-                : stateStorage === "attrs" && storedState
-                  ? clearVisibleNumberingFromAttrs(heading, storedState, options)
-                  : heading.markdown;
+            stateStorage === "attrs" && storedState
+                ? clearVisibleNumberingFromAttrs(
+                      markerCleanedHeading,
+                      storedState,
+                      options
+                  )
+                : markerCleanedHeading.markdown;
 
         if (finalRestored !== heading.markdown) {
             updates[heading.id] = finalRestored;
@@ -604,7 +632,9 @@ export function clearAllHeadingNumbering(
         const withoutMarker = stripMarker(parts.content, {
             restorePrefix: false,
         });
-        const cleanedContent = stripHeadingNumberPrefix(withoutMarker);
+        const cleanedContent = stripHeadingNumberPrefix(
+            stripLegacyMarkerArtifacts(withoutMarker)
+        );
         const restoredMarkdown = `${parts.prefix}${cleanedContent}`;
 
         if (restoredMarkdown !== heading.markdown) {

--- a/tests/numbering/numbering_engine.test.ts
+++ b/tests/numbering/numbering_engine.test.ts
@@ -28,6 +28,9 @@ const DEFAULT_CONFIG: NumberingConfig = {
     useChineseNumbers: [false, false, false, false, false, false],
 };
 
+const MALFORMED_MARKER =
+    "\u2063\u2064\u2063\u200c\u200c\u200d\u200c\u2064\u2063\u2064";
+
 function toBlocksFromUpdates(
     source: HeadingBlock[],
     updates: Record<string, string>
@@ -533,6 +536,66 @@ test("clearAutoNumbering removes visible numbering after title edits even when d
         [BACKUP_PREFIX_ATTR]: "",
         [CONTENT_DIGEST_ATTR]: "",
     });
+});
+
+test("planHeadingUpdates strips malformed legacy marker artifacts during attr migration", () => {
+    const source: HeadingBlock[] = [
+        {
+            id: "a",
+            subtype: "h1",
+            markdown: `# Title${MALFORMED_MARKER}`,
+            attrs: {},
+        },
+    ];
+
+    const result = planHeadingUpdates(source, DEFAULT_CONFIG);
+
+    assert.equal(result.updates.a, "# 1. Title");
+    assert.deepEqual(result.attrs.a, {
+        [AUTO_NUMBER_ATTR]: "1.",
+        [BACKUP_PREFIX_ATTR]: "",
+        [CONTENT_DIGEST_ATTR]: computeContentDigest("Title"),
+    });
+});
+
+test("clearAutoNumbering removes malformed legacy marker artifacts after attr migration", () => {
+    const source: HeadingBlock[] = [
+        {
+            id: "a",
+            subtype: "h1",
+            markdown: `# 1. Title${MALFORMED_MARKER}`,
+            attrs: {
+                [AUTO_NUMBER_ATTR]: "1. ",
+                [BACKUP_PREFIX_ATTR]: "",
+                [CONTENT_DIGEST_ATTR]: computeContentDigest("Title"),
+            },
+        },
+    ];
+
+    const result = clearAutoNumbering(source, { preservePrefix: false });
+
+    assert.equal(result.updates.a, "# Title");
+    assert.deepEqual(result.attrs.a, {
+        [AUTO_NUMBER_ATTR]: "",
+        [BACKUP_PREFIX_ATTR]: "",
+        [CONTENT_DIGEST_ATTR]: "",
+    });
+});
+
+test("clearAllHeadingNumbering removes malformed legacy marker artifacts without attr state", () => {
+    const source: HeadingBlock[] = [
+        {
+            id: "a",
+            subtype: "h1",
+            markdown: `# 1. Title${MALFORMED_MARKER}`,
+            attrs: {},
+        },
+    ];
+
+    const result = clearAllHeadingNumbering(source, { stateStorage: "attrs" });
+
+    assert.equal(result.updates.a, "# Title");
+    assert.deepEqual(result.attrs, {});
 });
 
 test("clearAutoNumbering preserves exact leading numeric content for true separator-free formats when digest is stale", () => {


### PR DESCRIPTION
## Summary
This PR fixes a remaining issue from the issue #38 follow-up work: old heading content created by earlier plugin versions could still keep invisible marker artifacts even after the numbering state was moved to block attributes in 2.2.3.

## What changed
- Added a fallback cleanup path for malformed legacy marker artifacts that can no longer be decoded by the old marker parser.
- Applied that cleanup during heading renumbering, disable-numbering, and clear-all flows.
- Added regression tests covering malformed legacy marker cleanup for:
  - normal update/migration to attribute-backed state
  - disabling numbering
  - clearing all heading numbering

## Why
Issue #38 was originally about the plugin writing large amounts of invisible characters into heading blocks.

The previous fix moved numbering state out of heading text and into block attributes, which stopped new marker data from being written into document content. However, user feedback after 2.2.3 showed that some documents still contained invisible characters created by older versions, and those characters were not always cleaned up automatically.

Reproducing the problem with existing real data showed that 2.2.3 handled valid legacy markers, but it still skipped older malformed marker payloads. When that happened, the old invisible marker sentinels remained in the heading text, so affected documents were not fully repaired by normal numbering refresh or cleanup operations.

## Implementation details
- The fix adds a legacy marker artifact stripper that removes the old marker start/end sentinels and surrounding invisible residue even when the payload is malformed and cannot be parsed.
- The sanitizer is now used before migrating heading content to attribute-backed numbering state.
- The same sanitizer is also applied in clear and clear-all paths so old damaged headings can be repaired consistently.
- The attribute-based numbering state format introduced in 2.2.3 is unchanged; this PR only improves compatibility and cleanup for legacy data.