### PR TITLE
Fix exported heading levels by writing numbered headings as markdown

### DIFF
--- a/src/infra/siyuan_api.ts
+++ b/src/infra/siyuan_api.ts
@@ -47,6 +47,7 @@ class SiyuanApiRequestError extends Error {
 }
 
 const ATTR_UPDATE_CONCURRENCY = 8;
+export const MIN_MARKDOWN_BATCH_UPDATE_APP_VERSION = "3.1.25";
 
 export interface SiyuanApi {
     getVersion(): Promise<string>;
@@ -318,6 +319,8 @@ export function createSiyuanApi(fetchImpl: typeof fetch = fetch): SiyuanApi {
             return;
         }
 
+        // Direct markdown batch writes rely on the plugin manifest requiring
+        // SiYuan versions that support /api/block/batchUpdateBlock for markdown.
         await updateBlocksBatch(fetchImpl, updates, dataType);
     }
 

--- a/src/infra/siyuan_api.ts
+++ b/src/infra/siyuan_api.ts
@@ -24,14 +24,6 @@ interface IHeadingAttrsPayload {
     [key: string]: string;
 }
 
-interface IUpdateBlockOperation {
-    data?: string;
-}
-
-interface IUpdateBlockResult {
-    doOperations?: IUpdateBlockOperation[];
-}
-
 class SiyuanApiRequestError extends Error {
     path: string;
     status: number;
@@ -157,48 +149,6 @@ async function updateBlocksBatch(
         dataType,
         data,
     });
-}
-
-async function requestSingleBlockUpdate<T>(
-    fetchImpl: typeof fetch,
-    id: string,
-    data: string,
-    dataType: BlockDataType
-): Promise<T> {
-    return requestApi<T>(fetchImpl, "/api/block/updateBlock", {
-        id,
-        data,
-        dataType,
-    });
-}
-
-async function renderMarkdownAsDom(
-    fetchImpl: typeof fetch,
-    id: string,
-    markdown: string
-): Promise<string> {
-    const result = await requestSingleBlockUpdate<IUpdateBlockResult[]>(
-        fetchImpl,
-        id,
-        markdown,
-        "markdown"
-    );
-    const dom = result[0]?.doOperations?.[0]?.data;
-    if (!dom) {
-        throw new Error(`SiYuan API did not return rendered DOM for block: ${id}`);
-    }
-
-    return dom;
-}
-
-async function updateBlocksViaRenderedDom(
-    fetchImpl: typeof fetch,
-    updates: Record<string, string>
-): Promise<void> {
-    for (const [id, markdown] of Object.entries(updates)) {
-        const renderedDom = await renderMarkdownAsDom(fetchImpl, id, markdown);
-        await requestSingleBlockUpdate<unknown>(fetchImpl, id, renderedDom, "dom");
-    }
 }
 
 async function updateAttrsBatch(
@@ -365,11 +315,6 @@ export function createSiyuanApi(fetchImpl: typeof fetch = fetch): SiyuanApi {
         dataType: BlockDataType
     ): Promise<void> {
         if (Object.keys(updates).length === 0) {
-            return;
-        }
-
-        if (dataType === "markdown") {
-            await updateBlocksViaRenderedDom(fetchImpl, updates);
             return;
         }
 

--- a/src/infra/siyuan_api.ts
+++ b/src/infra/siyuan_api.ts
@@ -1,4 +1,5 @@
 import { HeadingBlock } from "../numbering/numbering_engine";
+import { compareVersion } from "../utils/version_utils";
 
 type BlockDataType = "markdown" | "dom";
 
@@ -48,6 +49,12 @@ class SiyuanApiRequestError extends Error {
 
 const ATTR_UPDATE_CONCURRENCY = 8;
 export const MIN_MARKDOWN_BATCH_UPDATE_APP_VERSION = "3.1.25";
+
+function buildUnsupportedMarkdownBatchVersionError(version: string): Error {
+    return new Error(
+        `Markdown batch updates require SiYuan >= ${MIN_MARKDOWN_BATCH_UPDATE_APP_VERSION}, received ${version}.`
+    );
+}
 
 export interface SiyuanApi {
     getVersion(): Promise<string>;
@@ -319,8 +326,18 @@ export function createSiyuanApi(fetchImpl: typeof fetch = fetch): SiyuanApi {
             return;
         }
 
-        // Direct markdown batch writes rely on the plugin manifest requiring
-        // SiYuan versions that support /api/block/batchUpdateBlock for markdown.
+        if (dataType === "markdown") {
+            const version = await getVersion();
+            if (
+                compareVersion(
+                    version,
+                    MIN_MARKDOWN_BATCH_UPDATE_APP_VERSION
+                ) < 0
+            ) {
+                throw buildUnsupportedMarkdownBatchVersionError(version);
+            }
+        }
+
         await updateBlocksBatch(fetchImpl, updates, dataType);
     }
 

--- a/tests/infra/siyuan_api.test.ts
+++ b/tests/infra/siyuan_api.test.ts
@@ -506,8 +506,32 @@ test("updateBlocks uses batchUpdateBlock for dom updates when version >= 3.1.25"
     assert.equal(calledBatch.length, 1);
 });
 
-test("updateBlocks sends markdown updates directly without DOM bridge", async () => {
-    const fake = createFakeFetch();
+test("updateBlocks rejects markdown batch updates on unsupported SiYuan versions", async () => {
+    const fake = createFakeFetch("3.1.24");
+    const api = createSiyuanApi(fake.fetch);
+
+    await assert.rejects(
+        () =>
+            api.updateBlocks(
+                {
+                    a: "# 1. Title A",
+                },
+                "markdown"
+            ),
+        /Markdown batch updates require SiYuan >= 3\.1\.25, received 3\.1\.24\./i
+    );
+
+    const updateCalls = fake.calls.filter((call) => call.url === "/api/block/updateBlock");
+    const batchCalls = fake.calls.filter(
+        (call) => call.url === "/api/block/batchUpdateBlock"
+    );
+
+    assert.equal(updateCalls.length, 0);
+    assert.equal(batchCalls.length, 0);
+});
+
+test("updateBlocks sends markdown updates directly on supported SiYuan versions", async () => {
+    const fake = createFakeFetch("3.1.25");
     const api = createSiyuanApi(fake.fetch);
 
     await api.updateBlocks(

--- a/tests/infra/siyuan_api.test.ts
+++ b/tests/infra/siyuan_api.test.ts
@@ -1,7 +1,13 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
 
-import { createSiyuanApi } from "../../src/infra/siyuan_api";
+import {
+    createSiyuanApi,
+    MIN_MARKDOWN_BATCH_UPDATE_APP_VERSION,
+} from "../../src/infra/siyuan_api";
+import { compareVersion } from "../../src/utils/version_utils";
 
 type IFetchCall = {
     url: string;
@@ -527,6 +533,21 @@ test("updateBlocks sends markdown updates directly without DOM bridge", async ()
             },
         ],
     });
+});
+
+test("plugin manifest keeps minimum app version aligned with direct markdown batch updates", () => {
+    const manifestPath = path.resolve(process.cwd(), "plugin.json");
+    const manifest = JSON.parse(
+        readFileSync(manifestPath, "utf8")
+    ) as { minAppVersion?: string };
+
+    assert.equal(
+        compareVersion(
+            manifest.minAppVersion || "0.0.0",
+            MIN_MARKDOWN_BATCH_UPDATE_APP_VERSION
+        ) >= 0,
+        true
+    );
 });
 
 test("flushTransactions calls /api/sqlite/flushTransaction", async () => {

--- a/tests/infra/siyuan_api.test.ts
+++ b/tests/infra/siyuan_api.test.ts
@@ -319,68 +319,6 @@ function createFakeFetchWithKramdownOrder(version = "3.5.5") {
     };
 }
 
-function createFakeFetchForMarkdownBridge() {
-    const calls: IFetchCall[] = [];
-
-    const fakeFetch: typeof fetch = (async (
-        input: RequestInfo | URL,
-        init?: RequestInit
-    ) => {
-        const url = String(input);
-        const body = init?.body ? JSON.parse(String(init.body)) : undefined;
-        calls.push({ url, body });
-
-        if (url === "/api/block/updateBlock") {
-            const payload = body as {
-                id?: string;
-                dataType?: string;
-                data?: string;
-            };
-            if (payload.dataType === "markdown") {
-                return new Response(
-                    JSON.stringify({
-                        code: 0,
-                        msg: "",
-                        data: [
-                            {
-                                doOperations: [
-                                    {
-                                        data: `<div data-node-id="${payload.id}">rendered:${payload.data}</div>`,
-                                    },
-                                ],
-                            },
-                        ],
-                    }),
-                    { status: 200 }
-                );
-            }
-
-            return new Response(
-                JSON.stringify({
-                    code: 0,
-                    msg: "",
-                    data: null,
-                }),
-                { status: 200 }
-            );
-        }
-
-        return new Response(
-            JSON.stringify({
-                code: 0,
-                msg: "",
-                data: null,
-            }),
-            { status: 200 }
-        );
-    }) as typeof fetch;
-
-    return {
-        calls,
-        fetch: fakeFetch,
-    };
-}
-
 function createFakeFetchWithAttrBatchRace() {
     const calls: IFetchCall[] = [];
     let resolvedA = false;
@@ -562,8 +500,8 @@ test("updateBlocks uses batchUpdateBlock for dom updates when version >= 3.1.25"
     assert.equal(calledBatch.length, 1);
 });
 
-test("updateBlocks bridges markdown updates through rendered DOM operations", async () => {
-    const fake = createFakeFetchForMarkdownBridge();
+test("updateBlocks sends markdown updates directly without DOM bridge", async () => {
+    const fake = createFakeFetch();
     const api = createSiyuanApi(fake.fetch);
 
     await api.updateBlocks(
@@ -574,16 +512,20 @@ test("updateBlocks bridges markdown updates through rendered DOM operations", as
     );
 
     const updateCalls = fake.calls.filter((call) => call.url === "/api/block/updateBlock");
-    assert.equal(updateCalls.length, 2);
-    assert.deepEqual(updateCalls[0].body, {
-        id: "a",
+    const batchCalls = fake.calls.filter(
+        (call) => call.url === "/api/block/batchUpdateBlock"
+    );
+
+    assert.equal(updateCalls.length, 0);
+    assert.equal(batchCalls.length, 1);
+    assert.deepEqual(batchCalls[0].body, {
         dataType: "markdown",
-        data: "# 1. Title A",
-    });
-    assert.deepEqual(updateCalls[1].body, {
-        id: "a",
-        dataType: "dom",
-        data: '<div data-node-id="a">rendered:# 1. Title A</div>',
+        data: [
+            {
+                id: "a",
+                data: "# 1. Title A",
+            },
+        ],
     });
 });
 


### PR DESCRIPTION
Closes #39

## What changed
- switched heading content updates in `SiyuanApi.updateBlocks(..., "markdown")` from the old markdown-to-rendered-DOM bridge to direct markdown batch updates
- removed the per-block `/api/block/updateBlock` render/write flow that converted heading markdown into embedded HTML
- added an explicit SiYuan version gate for markdown batch updates and throw a clear runtime error when the app version is below `3.1.25`
- exposed the minimum supported version as a shared constant and added a regression test that keeps `plugin.json` aligned with that requirement
- updated API tests to cover unsupported versions, supported versions, and the manifest/version contract

## Why
Issue #39 reports that enabling auto numbering can break exported markdown headings. The previous implementation rendered numbered headings to DOM and then wrote that DOM back into the block. That kept the editor view updated, but it could export headings in a broken shape where the heading marker and the rendered HTML were split across lines, which breaks heading-level rendering and downstream DOCX heading semantics.

Writing the numbered heading back as markdown preserves valid heading syntax in exported markdown while keeping the numbering behavior unchanged for supported SiYuan versions.

## Important implementation details
- markdown updates now use `/api/block/batchUpdateBlock` with `dataType: "markdown"` instead of round-tripping through DOM
- direct markdown batch writes only work on SiYuan `>= 3.1.25`, so the API layer now checks the version before attempting the request
- the plugin manifest already requires `3.1.25`; the new test ensures the runtime contract and distribution metadata do not drift apart
- DOM batch updates are unchanged; the version gate only applies to markdown writes

## Validation
- `pixi run pnpm test`
- `pixi run pnpm build`