### PR TITLE
Fix stale numbering-state handling for numeric heading titles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siyuan-auto-seq-number",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "A SiYuan Plugin to auto generate sequence number for headers",
   "main": ".src/index.js",
   "scripts": {

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "name": "siyuan-auto-seq-number",
   "author": "Logic Tan",
   "url": "https://github.com/dale0525/siyuan-auto-seq-number",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "minAppVersion": "3.1.25",
   "backends": [
     "all"

--- a/src/numbering/numbering_engine.ts
+++ b/src/numbering/numbering_engine.ts
@@ -361,6 +361,7 @@ function extractLegacyPrefix(text: string, number: string): string {
     }
 
     const candidates = buildLegacyNumberCandidates(number);
+    const trimmedNumber = number.replace(/\s+$/, "");
     for (const candidate of candidates) {
         if (!candidate || !text.startsWith(candidate)) {
             continue;
@@ -373,6 +374,9 @@ function extractLegacyPrefix(text: string, number: string): string {
         const spaceMatch = rest.match(/^\s+/);
         if (spaceMatch) {
             return candidate + spaceMatch[0];
+        }
+        if (candidate.length < trimmedNumber.length) {
+            continue;
         }
         return candidate;
     }

--- a/tests/numbering/numbering_engine.test.ts
+++ b/tests/numbering/numbering_engine.test.ts
@@ -165,6 +165,30 @@ test("planHeadingUpdates does not treat plain numeric title content as an existi
     assert.equal(result.updates.b, "# 2. 234");
 });
 
+test("clearAutoNumbering keeps plain numeric title content when stored attrs are stale", () => {
+    const source: HeadingBlock[] = [
+        {
+            id: "a",
+            subtype: "h1",
+            markdown: "# 234",
+            attrs: {
+                [AUTO_NUMBER_ATTR]: "2. ",
+                [BACKUP_PREFIX_ATTR]: "",
+                [CONTENT_DIGEST_ATTR]: computeContentDigest("Different title"),
+            },
+        },
+    ];
+
+    const result = clearAutoNumbering(source, { preservePrefix: false });
+
+    assert.equal(result.updates.a, undefined);
+    assert.deepEqual(result.attrs.a, {
+        [AUTO_NUMBER_ATTR]: "",
+        [BACKUP_PREFIX_ATTR]: "",
+        [CONTENT_DIGEST_ATTR]: "",
+    });
+});
+
 test("clearAutoNumbering removes visible numbering even when stored attrs are stale", () => {
     const source: HeadingBlock[] = [
         {
@@ -338,6 +362,27 @@ test("planHeadingUpdates keeps exact leading numeric content for true separator-
     const result = planHeadingUpdates(source, config);
 
     assert.equal(result.updates.b, "# 21st steps");
+});
+
+test("planHeadingUpdates keeps chinese numeric title content when stored attrs are stale", () => {
+    const source: HeadingBlock[] = [
+        {
+            id: "a",
+            subtype: "h1",
+            markdown: "# 二三四",
+            attrs: {
+                [AUTO_NUMBER_ATTR]: "二、 ",
+                [BACKUP_PREFIX_ATTR]: "",
+            },
+        },
+    ];
+
+    const result = planHeadingUpdates(source, {
+        formats: ["{1}、 ", "{1}.{2} ", "{1}.{2}.{3} ", "{1}.{2}.{3}.{4} ", "{1}.{2}.{3}.{4}.{5} ", "{1}.{2}.{3}.{4}.{5}.{6} "],
+        useChineseNumbers: [true, false, false, false, false, false],
+    });
+
+    assert.equal(result.updates.a, "# 一、 二三四");
 });
 
 test("clearAutoNumbering removes visible numbering when stored number still matches but digest is stale", () => {
@@ -518,6 +563,30 @@ test("clearAllHeadingNumbering removes visible numbering for true separator-free
     const result = clearAllHeadingNumbering(source, { stateStorage: "attrs" });
 
     assert.equal(result.updates.a, "# Title");
+    assert.deepEqual(result.attrs.a, {
+        [AUTO_NUMBER_ATTR]: "",
+        [BACKUP_PREFIX_ATTR]: "",
+        [CONTENT_DIGEST_ATTR]: "",
+    });
+});
+
+test("clearAllHeadingNumbering keeps plain numeric title content when stored attrs are stale", () => {
+    const source: HeadingBlock[] = [
+        {
+            id: "a",
+            subtype: "h1",
+            markdown: "# 234",
+            attrs: {
+                [AUTO_NUMBER_ATTR]: "2. ",
+                [BACKUP_PREFIX_ATTR]: "",
+                [CONTENT_DIGEST_ATTR]: computeContentDigest("Different title"),
+            },
+        },
+    ];
+
+    const result = clearAllHeadingNumbering(source, { stateStorage: "attrs" });
+
+    assert.equal(result.updates.a, undefined);
     assert.deepEqual(result.attrs.a, {
         [AUTO_NUMBER_ATTR]: "",
         [BACKUP_PREFIX_ATTR]: "",

--- a/tests/numbering/numbering_engine.test.ts
+++ b/tests/numbering/numbering_engine.test.ts
@@ -154,6 +154,17 @@ test("planHeadingUpdates keeps numeric title content when stored attrs are stale
     assert.equal(result.updates.a, "# 1. 3 things to know");
 });
 
+test("planHeadingUpdates does not treat plain numeric title content as an existing separated prefix", () => {
+    const source: HeadingBlock[] = [
+        { id: "a", subtype: "h1", markdown: "# Intro" },
+        { id: "b", subtype: "h1", markdown: "# 234" },
+    ];
+
+    const result = planHeadingUpdates(source, DEFAULT_CONFIG);
+
+    assert.equal(result.updates.b, "# 2. 234");
+});
+
 test("clearAutoNumbering removes visible numbering even when stored attrs are stale", () => {
     const source: HeadingBlock[] = [
         {

--- a/tests/numbering/regression-cases.test.ts
+++ b/tests/numbering/regression-cases.test.ts
@@ -28,3 +28,33 @@ test("handles discontinuous heading levels without counter drift", () => {
     assert.match(result.updates.b, /^####\s+1\.1\s/);
     assert.match(result.updates.c, /^###\s+1\.2\s/);
 });
+
+test("preserves plain numeric heading titles when stale numbering attrs exist", () => {
+    const result = planHeadingUpdates(
+        [
+            { id: "a", subtype: "h1", markdown: "# Intro" },
+            {
+                id: "b",
+                subtype: "h1",
+                markdown: "# 234",
+                attrs: {
+                    "custom-seq-number": "7. ",
+                    "custom-seq-backup-prefix": "",
+                },
+            },
+        ],
+        {
+            formats: [
+                "{1}. ",
+                "{1}.{2} ",
+                "{1}.{2}.{3} ",
+                "{1}.{2}.{3}.{4} ",
+                "{1}.{2}.{3}.{4}.{5} ",
+                "{1}.{2}.{3}.{4}.{5}.{6} ",
+            ],
+            useChineseNumbers: [false, false, false, false, false, false],
+        }
+    );
+
+    assert.equal(result.updates.b, "# 2. 234");
+});


### PR DESCRIPTION
## Summary
- fix stale numbering-state handling so plain numeric heading titles are not mistaken for an existing generated prefix
- preserve user-authored numeric and Chinese numeric heading content across update, clear, and clear-all flows when stored numbering attrs are stale
- add regression coverage for these stale-state cases and bump the package/plugin version to `2.2.5`

## Why
This PR addresses issue #42.

When a heading title is a plain number such as `234`, and the generated heading number is `2. `, the previous logic could treat the leading `2` as if it were part of an old generated prefix. That produced incorrect output such as `2. 34` instead of `2. 234`.

The goal of this change is to make numbering updates resilient when stored numbering metadata is stale, so user-entered heading content is preserved instead of being partially stripped.

## Implementation Details
- updated `extractLegacyPrefix` in `src/numbering/numbering_engine.ts` to avoid accepting shorter candidate matches unless they are followed by a real separator such as whitespace or punctuation
- this prevents partial prefix matches inside plain numeric titles while still allowing valid legacy-prefix cleanup paths to work as before
- expanded unit and regression tests to cover:
  - plain numeric titles during numbering updates
  - stale attr handling during `clearAutoNumbering`
  - stale attr handling during `clearAllHeadingNumbering`
  - Chinese numeric titles with stale attrs
- updated `package.json` and `plugin.json` version metadata from `2.2.4` to `2.2.5`

## Validation
- `pixi run pnpm test`