### PR TITLE
Fix batchUpdateBlock payload format for the SiYuan kernel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siyuan-auto-seq-number",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "A SiYuan Plugin to auto generate sequence number for headers",
   "main": ".src/index.js",
   "scripts": {

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "name": "siyuan-auto-seq-number",
   "author": "Logic Tan",
   "url": "https://github.com/dale0525/siyuan-auto-seq-number",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "minAppVersion": "3.1.25",
   "backends": [
     "all"

--- a/src/infra/siyuan_api.ts
+++ b/src/infra/siyuan_api.ts
@@ -148,14 +148,14 @@ async function updateBlocksBatch(
     updates: Record<string, string>,
     dataType: BlockDataType
 ): Promise<void> {
-    const data = Object.entries(updates).map(([id, content]) => ({
+    const blocks = Object.entries(updates).map(([id, content]) => ({
         id,
         data: content,
+        dataType,
     }));
 
     await requestApi<unknown>(fetchImpl, "/api/block/batchUpdateBlock", {
-        dataType,
-        data,
+        blocks,
     });
 }
 

--- a/tests/infra/siyuan_api.test.ts
+++ b/tests/infra/siyuan_api.test.ts
@@ -484,6 +484,20 @@ test("updateBlocks uses batchUpdateBlock for dom updates even when version < 3.1
     );
     assert.equal(calledUpdate.length, 0);
     assert.equal(calledBatch.length, 1);
+    assert.deepEqual(calledBatch[0].body, {
+        blocks: [
+            {
+                id: "a",
+                data: "# A",
+                dataType: "dom",
+            },
+            {
+                id: "b",
+                data: "## B",
+                dataType: "dom",
+            },
+        ],
+    });
 });
 
 test("updateBlocks uses batchUpdateBlock for dom updates when version >= 3.1.25", async () => {
@@ -549,11 +563,11 @@ test("updateBlocks sends markdown updates directly on supported SiYuan versions"
     assert.equal(updateCalls.length, 0);
     assert.equal(batchCalls.length, 1);
     assert.deepEqual(batchCalls[0].body, {
-        dataType: "markdown",
-        data: [
+        blocks: [
             {
                 id: "a",
                 data: "# 1. Title A",
+                dataType: "markdown",
             },
         ],
     });


### PR DESCRIPTION
## Summary
- send `/api/block/batchUpdateBlock` requests with a `blocks` array instead of the previous top-level `dataType` and `data` fields
- include `dataType` on each block entry so the payload matches what the SiYuan kernel actually parses
- extend the infra tests to assert the exact request body for both DOM and markdown batch updates

## Why
Issue #45 reported that updating heading numbering could fail because the plugin was calling `/api/block/batchUpdateBlock` with the wrong payload shape. The SiYuan kernel expects a `blocks` array where each item contains `id`, `data`, and `dataType`, so the previous request body could not be handled correctly.

## Implementation Details
- `updateBlocksBatch` now converts the update map into `blocks[]` entries and sends that structure directly to the batch endpoint
- the existing version gate for markdown batch updates is unchanged, so markdown batching still requires SiYuan `>= 3.1.25`
- tests now verify the concrete payload shape for DOM updates and markdown updates, which helps prevent this API contract from regressing again

Closes #45