### PR TITLE
Fix DOM heading numbering for subtype-only headings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siyuan-auto-seq-number",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "A SiYuan Plugin to auto generate sequence number for headers",
   "main": ".src/index.js",
   "scripts": {

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "name": "siyuan-auto-seq-number",
   "author": "Logic Tan",
   "url": "https://github.com/dale0525/siyuan-auto-seq-number",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "minAppVersion": "3.1.25",
   "backends": [
     "all"

--- a/src/utils/header_utils.ts
+++ b/src/utils/header_utils.ts
@@ -185,10 +185,16 @@ export function removeHeaderNumber(text: string, format: string): string {
  * @returns 标题级别（1-6），如果不是标题则返回0
  */
 export function getHeaderLevel(element: Element): number {
+    const subtype = element.getAttribute("data-subtype") || "";
+    const subtypeMatch = subtype.match(/^h([1-6])$/);
+    if (subtypeMatch) {
+        return Number.parseInt(subtypeMatch[1], 10);
+    }
+
     for (let i = 1; i <= 6; i++) {
         if (element.classList.contains(`h${i}`)) {
             return i;
         }
     }
     return 0;
-} 
+}

--- a/tests/plugin/dom-heading-fallback.test.ts
+++ b/tests/plugin/dom-heading-fallback.test.ts
@@ -6,6 +6,7 @@ import {
     buildDomClearUpdates,
     buildDomNumberingUpdates,
 } from "../../src/plugin/dom_heading_fallback";
+import { getHeaderLevel } from "../../src/utils/header_utils";
 
 const CONFIG = {
     formats: [
@@ -64,4 +65,19 @@ test("buildDomClearAllUpdates removes user-defined numbering", () => {
     assert.equal(updates.a, "一级标题1");
     assert.equal(updates.b, "二级标题1");
     assert.equal("c" in updates, false);
+});
+
+test("getHeaderLevel reads data-subtype when heading class is absent", () => {
+    const element = {
+        classList: {
+            contains() {
+                return false;
+            },
+        },
+        getAttribute(name: string) {
+            return name === "data-subtype" ? "h3" : null;
+        },
+    } as unknown as Element;
+
+    assert.equal(getHeaderLevel(element), 3);
 });


### PR DESCRIPTION
## Summary
- Fix DOM fallback heading level detection by reading `data-subtype="h1"` through `h6` before falling back to heading classes.
- Add a regression test for heading elements that have `data-subtype` but no `hN` class.
- Bump the plugin and package version to `2.2.7` for the issue 47 fix release.

## Why
Issue #47 reported incorrect generated heading numbers where some headings were skipped. The screenshot showed headings present in the outline but missing generated numbering, which matches the DOM fallback path collecting heading elements by `data-subtype` while `getHeaderLevel` only recognized `.hN` classes.

## Implementation Details
- `getHeaderLevel` now parses `data-subtype` first, preserving the existing class-based fallback for compatibility.
- The regression test covers subtype-only DOM elements so future changes cannot reintroduce this skip.
- Verified with `pixi run pnpm run verify`, the pre-push hook, and a live SiYuan dynamic test using a temporary document modeled after the issue screenshot.