### PR TITLE
Fix auto numbering for large SiYuan documents

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siyuan-auto-seq-number",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "description": "A SiYuan Plugin to auto generate sequence number for headers",
   "main": ".src/index.js",
   "scripts": {

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "name": "siyuan-auto-seq-number",
   "author": "Logic Tan",
   "url": "https://github.com/dale0525/siyuan-auto-seq-number",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "minAppVersion": "3.1.25",
   "backends": [
     "all"

--- a/src/infra/siyuan_api.ts
+++ b/src/infra/siyuan_api.ts
@@ -48,6 +48,7 @@ class SiyuanApiRequestError extends Error {
 }
 
 const ATTR_UPDATE_CONCURRENCY = 8;
+const HEADING_QUERY_PAGE_SIZE = 512;
 export const MIN_MARKDOWN_BATCH_UPDATE_APP_VERSION = "3.1.25";
 
 function buildUnsupportedMarkdownBatchVersionError(version: string): Error {
@@ -192,18 +193,41 @@ async function updateAttrsBatch(
     }
 }
 
+async function queryDocHeadingRowsPage(
+    fetchImpl: typeof fetch,
+    docId: string,
+    includeIal: boolean,
+    offset: number
+): Promise<ISqlHeadingRow[]> {
+    const escapedDocId = escapeSqlString(docId);
+    const columns = includeIal ? "id, markdown, subtype, ial" : "id, markdown, subtype";
+    const sql = `select ${columns} from blocks where root_id = '${escapedDocId}' and subtype in ('h1','h2','h3','h4','h5','h6') order by sort asc, id asc limit ${HEADING_QUERY_PAGE_SIZE} offset ${offset}`;
+
+    return requestApi<ISqlHeadingRow[]>(fetchImpl, "/api/query/sql", {
+        stmt: sql,
+    });
+}
+
 async function queryDocHeadingRows(
     fetchImpl: typeof fetch,
     docId: string,
     includeIal: boolean
 ): Promise<ISqlHeadingRow[]> {
-    const escapedDocId = escapeSqlString(docId);
-    const columns = includeIal ? "id, markdown, subtype, ial" : "id, markdown, subtype";
-    const sql = `select ${columns} from blocks where root_id = '${escapedDocId}' and subtype in ('h1','h2','h3','h4','h5','h6') order by sort asc`;
+    const rows: ISqlHeadingRow[] = [];
 
-    return requestApi<ISqlHeadingRow[]>(fetchImpl, "/api/query/sql", {
-        stmt: sql,
-    });
+    for (let offset = 0; ; offset += HEADING_QUERY_PAGE_SIZE) {
+        const page = await queryDocHeadingRowsPage(
+            fetchImpl,
+            docId,
+            includeIal,
+            offset
+        );
+        rows.push(...page);
+
+        if (page.length < HEADING_QUERY_PAGE_SIZE) {
+            return rows;
+        }
+    }
 }
 
 function reorderHeadingRowsByKramdown(

--- a/src/plugin/doc_id.ts
+++ b/src/plugin/doc_id.ts
@@ -2,8 +2,14 @@ function readString(value: unknown): string | null {
     return typeof value === "string" && value.trim() ? value : null;
 }
 
-export function resolveDocId(protyle: unknown): string | null {
-    const record = (protyle || {}) as Record<string, unknown>;
+function readRecord(value: unknown): Record<string, unknown> {
+    return value && typeof value === "object"
+        ? (value as Record<string, unknown>)
+        : {};
+}
+
+function readDocIdFromCandidate(candidate: unknown): string | null {
+    const record = readRecord(candidate);
     const background = (record.background || {}) as Record<string, unknown>;
     const ial = (background.ial || {}) as Record<string, unknown>;
     const block = (record.block || {}) as Record<string, unknown>;
@@ -16,4 +22,23 @@ export function resolveDocId(protyle: unknown): string | null {
         readString(options.blockId) ||
         null
     );
+}
+
+function resolveCandidates(protyle: unknown): unknown[] {
+    const record = readRecord(protyle);
+    const model = readRecord(record.model);
+    const editor = readRecord(model.editor);
+
+    return [record, record.protyle, editor, editor.protyle].filter(Boolean);
+}
+
+export function resolveDocId(protyle: unknown): string | null {
+    for (const candidate of resolveCandidates(protyle)) {
+        const docId = readDocIdFromCandidate(candidate);
+        if (docId) {
+            return docId;
+        }
+    }
+
+    return null;
 }

--- a/tests/infra/siyuan_api.test.ts
+++ b/tests/infra/siyuan_api.test.ts
@@ -149,6 +149,70 @@ function createFakeFetchTypeSensitive(version = "3.1.25") {
     };
 }
 
+function createFakeFetchWithSqlDefaultLimit(totalRows = 70) {
+    const calls: IFetchCall[] = [];
+    const rows = Array.from({ length: totalRows }, (_, index) => ({
+        id: `h${index + 1}`,
+        markdown: `# H${index + 1}`,
+        subtype: "h1",
+        ial: "",
+    }));
+
+    const fakeFetch: typeof fetch = (async (
+        input: RequestInfo | URL,
+        init?: RequestInit
+    ) => {
+        const url = String(input);
+        const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+        calls.push({ url, body });
+
+        if (url === "/api/query/sql") {
+            const stmt = String((body as { stmt?: unknown })?.stmt || "");
+            const limitMatch = stmt.match(/\blimit\s+(\d+)/i);
+            const offsetMatch = stmt.match(/\boffset\s+(\d+)/i);
+            const limit = limitMatch ? Number.parseInt(limitMatch[1], 10) : 64;
+            const offset = offsetMatch ? Number.parseInt(offsetMatch[1], 10) : 0;
+
+            return new Response(
+                JSON.stringify({
+                    code: 0,
+                    msg: "",
+                    data: rows.slice(offset, offset + limit),
+                }),
+                { status: 200 }
+            );
+        }
+
+        if (url === "/api/block/getBlockKramdown") {
+            return new Response(
+                JSON.stringify({
+                    code: 0,
+                    msg: "",
+                    data: {
+                        id: "doc-id",
+                        kramdown: "",
+                    },
+                }),
+                { status: 200 }
+            );
+        }
+
+        return new Response(
+            JSON.stringify({
+                code: 0,
+                msg: "",
+                data: null,
+            }),
+            { status: 200 }
+        );
+    }) as typeof fetch;
+
+    return {
+        calls,
+        fetch: fakeFetch,
+    };
+}
+
 function createFakeFetchFlushUnsupported(version = "3.1.25") {
     const calls: IFetchCall[] = [];
 
@@ -633,6 +697,16 @@ test("getDocHeadingBlocks returns heading rows", async () => {
         ["a", "b"]
     );
     assert.equal(blocks[0].attrs?.["custom-auto-seq-number"], "1. ");
+});
+
+test("getDocHeadingBlocks reads beyond SiYuan SQL default row cap", async () => {
+    const fake = createFakeFetchWithSqlDefaultLimit(70);
+    const api = createSiyuanApi(fake.fetch);
+
+    const blocks = await api.getDocHeadingBlocks("doc-id");
+
+    assert.equal(blocks.length, 70);
+    assert.equal(blocks[69].id, "h70");
 });
 
 test("updateAttrs writes block attrs one block at a time", async () => {

--- a/tests/plugin/doc-id.test.ts
+++ b/tests/plugin/doc-id.test.ts
@@ -24,3 +24,33 @@ test("resolveDocId falls back to block rootID", () => {
 
     assert.equal(docId, "doc-root");
 });
+
+test("resolveDocId reads wrapped protyle document ids", () => {
+    assert.equal(
+        resolveDocId({
+            protyle: {
+                block: {
+                    rootID: "doc-wrapper",
+                },
+            },
+        }),
+        "doc-wrapper"
+    );
+
+    assert.equal(
+        resolveDocId({
+            model: {
+                editor: {
+                    protyle: {
+                        background: {
+                            ial: {
+                                id: "doc-nested",
+                            },
+                        },
+                    },
+                },
+            },
+        }),
+        "doc-nested"
+    );
+});


### PR DESCRIPTION
## Summary
- Page SiYuan heading SQL queries so documents with more than the API default row cap are fully processed.
- Resolve document ids from wrapped Protyle objects before falling back to DOM-only updates.
- Bump the plugin version to 2.2.8 and add regression coverage for both cases.

## Why
Fixes #47. The issue-provided Linux tutorial document contains 88 headings, but the SQL query path only read the first 64 rows when no explicit limit was present. That made auto numbering skip later headings after clearing and regenerating numbers.

## Implementation Details
- `getDocHeadingBlocks` now queries headings in pages with an explicit limit/offset and still reorders rows by kramdown when available.
- `resolveDocId` now checks top-level, `protyle`, `model.editor`, and `model.editor.protyle` candidates before using DOM fallback data.
- Added regression tests for SiYuan SQL default row cap behavior and wrapped Protyle document id resolution.

## Test Plan
- `pixi run pnpm run verify`
- Imported the issue-provided `Linux.sy.zip` into local SiYuan data at `D:\siyuan` and verified all 88 headings are read and numbered in one pass.